### PR TITLE
Turn off optimx start tests when fitting GG

### DIFF
--- a/R/clv_template_controlflow_predict.R
+++ b/R/clv_template_controlflow_predict.R
@@ -117,13 +117,13 @@ clv.template.controlflow.predict <- function(object, prediction.end, predict.spe
                       vX     = object@cbs$x,
                       vM_x   = object@cbs$Spending,
                       upper  = c(log(10000),log(10000),log(10000)),
-                      lower  = c(log(0),log(0),log(0)), 
+                      lower  = c(log(0),log(0),log(0)),
                       method = "L-BFGS-B",
                       control=list(trace = 0,
                                    # Do not perform starttests because it checks the scales with max(logpar)-min(logpar)
                                    #   but all standard start parameters are <= 0, hence there are no logpars what
                                    #   produces a warning
-                                   # starttests = FALSE,
+                                   starttests = FALSE,
                                    maxit=3000))
     p     <- exp(coef(results)[1,"p"])
     q     <- exp(coef(results)[1,"q"])


### PR DESCRIPTION
Because the start parameters are now 0, optimx' start parameter tests throw a warning because they calculate log() on them. Turn off the tests.