### PR TITLE
Bugfix: Fail CI if tests fail

### DIFF
--- a/tests/testthat/test_dummy_fail_test.R
+++ b/tests/testthat/test_dummy_fail_test.R
@@ -1,5 +1,0 @@
-test_that("Always fails", {
-  cat("alksfjasfl")
-  expect_silent(warning("Warning! NOW!"))
-  expect_silent(stop("FAIL! NOW!"))
-})


### PR DESCRIPTION
Currently passes even if a test fails because forgot stop_on_warning/fail. 
Also only report the most relevant output from the tests.