### PR TITLE
Reduce tests on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -34,9 +34,6 @@ jobs:
 
           # If on a release branch (name starts with 'release'),
           #   run all tests, including lengthy ones marked with skip_on_ci()
-          print(Sys.getenv("GITHUB_REF"))
-          print(Sys.getenv("GITHUB_BASE_REF"))
-          print(Sys.getenv("GITHUB_HEAD_REF"))
           if(grepl(pattern = "^release", x = Sys.getenv("GITHUB_HEAD_REF"))){
             Sys.setenv(CI="")
             print("On release branch: Run all tests")

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -35,7 +35,9 @@ jobs:
           # If on a release branch (name starts with 'release'),
           #   run all tests, including lengthy ones marked with skip_on_ci()
           print(Sys.getenv("GITHUB_REF"))
-          if(grepl(pattern = "^release", x = Sys.getenv("GITHUB_REF"))){
+          print(Sys.getenv("GITHUB_BASE_REF"))
+          print(Sys.getenv("GITHUB_HEAD_REF"))
+          if(grepl(pattern = "^release", x = Sys.getenv("GITHUB_HEAD_REF"))){
             Sys.setenv(CI="")
             print("On release branch: Run all tests")
           }else{

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -31,6 +31,17 @@ jobs:
         run: |
           library(testthat)
           library(devtools)
+
+          # If on a release branch (name starts with 'release'),
+          #   run all tests, including lengthy ones marked with skip_on_ci()
+          print(Sys.getenv("GITHUB_REF"))
+          if(grepl(pattern = "^release", x = Sys.getenv("GITHUB_REF"))){
+            Sys.setenv(CI="")
+            print("On release branch: Run all tests")
+          }else{
+            print("Not on release branch: Dont run all tests (skip_on_ci())")
+          }
+
           reporter <- RstudioReporter$new() # has to be defined outside capture.output to still print
           capture.output(devtools::test(reporter = reporter, stop_on_failure=TRUE, stop_on_warning=TRUE))
         shell: Rscript {0}

--- a/tests/testthat/helper_testthat_runability_common.R
+++ b/tests/testthat/helper_testthat_runability_common.R
@@ -24,6 +24,9 @@ fct.testthat.runability.common.out.of.the.box.with.hold <- function(method, clv.
 fct.testthat.runability.common.custom.model.start.params <- function(method, start.params.model, clv.data.noholdout, clv.data.withholdout){
   test_that("Works with custom model.start.params", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
+
     l.args.no.hold <- list(clv.data = clv.data.noholdout,   start.params.model = start.params.model, verbose=FALSE)
     l.args.hold <- list(clv.data = clv.data.withholdout, start.params.model = start.params.model, verbose=FALSE)
 
@@ -35,6 +38,9 @@ fct.testthat.runability.common.custom.model.start.params <- function(method, sta
 fct.testthat.runability.common.all.optimization.methods <- function(method, clv.data.noholdout, expected.message){
   test_that("Works for all optimx optimization methods", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
+
     l.args <- list(clv.data = clv.data.noholdout, optimx.args = list(control=list(all.methods=TRUE)), verbose=FALSE)
     expect_warning(do.call(what = method, args = l.args),
                    regexp = expected.message, all=TRUE)
@@ -45,6 +51,9 @@ fct.testthat.runability.common.multiple.optimization.methods <- function(method,
                                                                          DERT.not.implemented){
   test_that("Works fully with multiple optimization methods", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
+
     l.args <- list(clv.data = clv.data.noholdout, optimx.args = list(method = c("BFGS", "L-BFGS-B", "Nelder-Mead")), verbose=FALSE)
 
     expect_silent(m.no.hold <- do.call(what = method, args = l.args))
@@ -58,6 +67,7 @@ fct.testthat.runability.common.works.with.cor <- function(method, clv.data.holdo
                                                           names.params.model, DERT.not.implemented){
   test_that("Works with use.cor=T", {
     skip_on_cran()
+    skip_on_ci()
 
     l.args <- list(clv.data = clv.data.holdout, use.cor=TRUE, verbose=FALSE)
     expect_silent(m.cor <- do.call(what = method, args = l.args))
@@ -75,6 +85,8 @@ fct.testthat.runability.common.works.with.cor.start.params <- function(method, c
                                                                        names.params.model, DERT.not.implemented = DERT.not.implemented){
   test_that("Works with use.cor=T and start.params", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
 
     l.args <- list(clv.data = clv.data.holdout, use.cor=TRUE, start.param.cor = 0.0, verbose=FALSE)
     expect_silent(m.cor <- do.call(what = method, args = l.args))

--- a/tests/testthat/helper_testthat_runability_nocov.R
+++ b/tests/testthat/helper_testthat_runability_nocov.R
@@ -1,6 +1,8 @@
 fct.testthat.runability.nocov.custom.optimx.args <- function(method, clv.data.noholdout, clv.data.withholdout, optimx.args){
   test_that("Works with custom optimx.args", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
     l.args.no.hold <- list(clv.data = clv.data.noholdout, optimx.args = optimx.args)
     l.args.hold <- list(clv.data = clv.data.withholdout, optimx.args = optimx.args)
     expect_message(do.call(what = method, args = l.args.no.hold))
@@ -11,6 +13,8 @@ fct.testthat.runability.nocov.custom.optimx.args <- function(method, clv.data.no
 fct.testthat.runability.nocov.without.spending.data <- function(method, data.transactions){
   test_that("Works without spending data",{
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
     l.args <- list(clvdata(data.transactions = data.transactions, name.price = NULL, date.format = "ymd", time.unit = "w", estimation.split = 37),
                  verbose = FALSE)
     expect_silent(clv.nospending <- do.call(what = method, args = l.args))
@@ -24,6 +28,8 @@ fct.testthat.runability.nocov.without.spending.data <- function(method, data.tra
 fct.testthat.runability.nocov.predict.newdata.spending <- function(method, data.transactions){
   test_that("No spending fit can predict on newdata that has spending", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
     l.args <- list(clvdata(data.transactions = data.transactions, name.price = NULL, date.format = "ymd", time.unit = "w", estimation.split = 37),
                    verbose = FALSE)
     # No spending fit

--- a/tests/testthat/helper_testthat_runability_staticcov.R
+++ b/tests/testthat/helper_testthat_runability_staticcov.R
@@ -2,6 +2,8 @@
 fct.testthat.runability.staticcov.custom.model.covariate.start.params <- function(method, clv.data.holdout, clv.data.no.holdout, start.params.model){
   test_that("Works with custom model and covariate start parameters", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
     l.args.holdout <- list(clv.data = clv.data.holdout,    start.params.model = start.params.model,
                            start.params.life = c(Gender = 1, Channel=0.4), start.params.trans = c(Gender=1, Channel=2), verbose = FALSE)
     l.args.no.holdout <- list(clv.data = clv.data.no.holdout, start.params.model = start.params.model,
@@ -40,6 +42,8 @@ fct.testthat.runability.staticcov.works.with.2.constraints <- function(method, c
                                                                        param.names.model, DERT.not.implemented){
   test_that("Works with 2 constraints", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
 
     l.args.holdout <- list(clv.data = clv.data.holdout, names.cov.constr = c("Gender", "Channel"),verbose=FALSE)
     l.args.no.holdout <- list(clv.data = clv.data.no.holdout,   names.cov.constr = c("Gender", "Channel"),verbose=FALSE)
@@ -99,6 +103,8 @@ fct.testthat.runability.staticcov.works.with.0.lambdas <- function(method, clv.d
                                                                    param.names.model, DERT.not.implemented){
   test_that("Works with 0 regularization lambdas", {
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
 
     l.args.holdout <- list(clv.data = clv.data.holdout,   reg.lambdas = c(trans=0, life=0),verbose=FALSE)
     l.args.no.holdout <- list(clv.data = clv.data.no.holdout,reg.lambdas = c(trans=0, life=0),verbose=FALSE)
@@ -117,6 +123,8 @@ fct.testthat.runability.staticcov.works.with.combined.interlayers.without.cor <-
   test_that("Works with combined interlayers (without correlation)", {
     # Try all combinations of interlayers
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
 
     l.args.holdout <- list(clv.data = clv.data.holdout, names.cov.constr = c("Gender", "Channel"), reg.lambdas = c(trans=10, life=10),verbose=FALSE)
     l.args.no.holdout <- list(clv.data = clv.data.no.holdout, names.cov.constr = c("Gender", "Channel"), reg.lambdas = c(trans=10, life=10),verbose=FALSE)
@@ -139,6 +147,8 @@ fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor <- fu
   test_that("Works with combined interlayers (with correlation)", {
     # Try all combinations of interlayers
     skip_on_cran()
+    skip_on_ci()
+    skip_on_covr()
 
     l.args.holdout.1 = list(clv.data = clv.data.holdout, use.cor = TRUE, names.cov.constr = c("Gender", "Channel"),verbose=FALSE)
     l.args.no.holdout.1 = list(clv.data = clv.data.no.holdout, use.cor = TRUE, names.cov.constr = c("Gender", "Channel"), verbose=FALSE)


### PR DESCRIPTION
Skip less relevant tests which take a long time, unless on release branch. 
Use skip_on_ci(). Set env variable CI='' if on release branch.