### PR TITLE
Bugfix: Invalid covariate names

### DIFF
--- a/R/class_clv_data_staticcovariates.R
+++ b/R/class_clv_data_staticcovariates.R
@@ -113,27 +113,40 @@ clv.data.reduce.covariates <- function(clv.data, names.cov.life, names.cov.trans
 
 
 #' @importFrom stats model.frame model.matrix reformulate
-convert_userinput_covariatedata_dummies <- function(dt.cov.data, names.cov){
+convert_userinput_covariatedata <- function(dt.cov.data, names.cov){
+
+
+  # Make syntactically valid names
+  #   Rename data in order to be able to use model.frame() which requires legal names
+  original.cov.names <- names.cov
+  legal.cov.names    <- make.names(names.cov)
+  setnames(dt.cov.data, old = original.cov.names, new = legal.cov.names)
+
 
   # Use model.frame/model.matrix to convert cov data
-  #   numeric to numeric, char/factors to k-1 dummies
+  #   numeric stays numeric, char/factors to k-1 dummies
 
   # Always need intercept!
   #   to always get k-1 dummies, as no intercept implies k dummies in the
-  #   case of only a single catgorical covariate
-  f.covs <- reformulate(termlabels = names.cov,
+  #   case of only a single categorical covariate
+  f.covs <- reformulate(termlabels = legal.cov.names,
                         response = NULL,
                         intercept = TRUE)
 
   mf <- model.frame(f.covs, data = dt.cov.data)
   mm <- model.matrix(object = f.covs, data = dt.cov.data)
 
-  # Combine averything else (Id, maybe Cov.Date) and raw converted numeric covariate data
-  dt.cov <- cbind(dt.cov.data[, .SD, .SDcols=setdiff(colnames(dt.cov.data), names.cov)], # everything except cov data
-                  mm[, setdiff(colnames(mm), "(Intercept)"), drop=FALSE]) # everything except the Intercept
+  # Combine everything else (Id, maybe Cov.Date for dyncov) and raw converted numeric covariate data
+  dt.cov <- cbind(
+    # Id and Cov.Date from original data, everything except actual cov data
+    dt.cov.data[, .SD, .SDcols=setdiff(colnames(dt.cov.data), legal.cov.names)],
+    # everything except the Intercept: numeric, dummies, etc
+    mm[, setdiff(colnames(mm), "(Intercept)"), drop=FALSE])
 
-  names.cov <- setdiff(colnames(dt.cov), c("Id", "Cov.Date"))
+  # Read final names which in the case of dummies are completely different from
+  #   original.cov.names (or legal.cov.names)
+  final.names.cov <- setdiff(colnames(dt.cov), c("Id", "Cov.Date"))
 
-  return(list(data.cov = dt.cov, names.cov=names.cov))
+  return(list(data.cov = dt.cov, final.names.cov=final.names.cov))
 }
 

--- a/R/f_clvfitted_inputchecks.R
+++ b/R/f_clvfitted_inputchecks.R
@@ -271,7 +271,7 @@ check_user_data_namesconstr <- function(clv.fitted, names.cov.constr){
 check_user_data_emptyellipsis <- function(...){
 
   err.msg <- c()
-  if(length(list(...)) > 0)
+  if(...length() > 0)
     err.msg <- c(err.msg, "Any further parameters passed in ... are ignored because they are not needed!")
 
   return(err.msg)

--- a/R/f_generics_clvfittedtransactionsstaticcov_estimate.R
+++ b/R/f_generics_clvfittedtransactionsstaticcov_estimate.R
@@ -1,9 +1,9 @@
 # . clv.controlflow.estimate.check.inputs ------------------------------------------------------------------------------
 setMethod(f = "clv.controlflow.estimate.check.inputs", signature = signature(clv.fitted="clv.fitted.transactions.static.cov"), definition = function(clv.fitted,  start.params.model, optimx.args, verbose, # clv.fitted input args
-                                                                                                                                 names.cov.life, names.cov.trans,
-                                                                                                                                 start.params.life, start.params.trans,
-                                                                                                                                 reg.lambdas,
-                                                                                                                                 names.cov.constr, start.params.constr, cl, ...){
+                                                                                                                                                     names.cov.life, names.cov.trans,
+                                                                                                                                                     start.params.life, start.params.trans,
+                                                                                                                                                     reg.lambdas,
+                                                                                                                                                     names.cov.constr, start.params.constr, cl, ...){
 
   # check input for clv.fitted.transactions
   callNextMethod()
@@ -57,7 +57,7 @@ setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitte
 
   # Reduce to user's desired covariates only -----------------------------------------------------------
   clv.fitted@clv.data <- clv.data.reduce.covariates(clv.data=clv.fitted@clv.data, names.cov.life=names.cov.life,
-                                             names.cov.trans=names.cov.trans)
+                                                    names.cov.trans=names.cov.trans)
 
   # is regularization used? ---------------------------------------------------------------------------
   #   Yes:  Indicate and store lambdas

--- a/R/f_interface_setdynamiccovariates.R
+++ b/R/f_interface_setdynamiccovariates.R
@@ -157,14 +157,14 @@ SetDynamicCovariates <- function(clv.data, data.cov.life, data.cov.trans, names.
 
   # Convert the covariate data to dummies ---------------------------------------------------------------
   #   keep numbers, char/factors to dummies
-  l.covs.life  <- convert_userinput_covariatedata_dummies(dt.cov.data = data.cov.life,  names.cov=names.cov.life)
-  l.covs.trans <- convert_userinput_covariatedata_dummies(dt.cov.data = data.cov.trans, names.cov=names.cov.trans)
+  l.covs.life  <- convert_userinput_covariatedata(dt.cov.data = data.cov.life,  names.cov=names.cov.life)
+  l.covs.trans <- convert_userinput_covariatedata(dt.cov.data = data.cov.trans, names.cov=names.cov.trans)
 
   # The cov names now are different because of the dummies!
   data.cov.life  <- l.covs.life$data.cov
   data.cov.trans <- l.covs.trans$data.cov
-  names.cov.life  <- l.covs.life$names.cov
-  names.cov.trans <- l.covs.trans$names.cov
+  names.cov.life  <- l.covs.life$final.names.cov
+  names.cov.trans <- l.covs.trans$final.names.cov
 
   setkeyv(data.cov.life,  cols = c("Id", "Cov.Date"))
   setkeyv(data.cov.trans, cols = c("Id", "Cov.Date"))

--- a/R/f_interface_setstaticcovariates.R
+++ b/R/f_interface_setstaticcovariates.R
@@ -62,7 +62,7 @@ SetStaticCovariates <- function(clv.data, data.cov.life, data.cov.trans, names.c
   data.cov.trans[, Id := .convert_userinput_dataid(Id)]
 
   # Make static cov specific checks on covariate data
-  #   only after if is DT because heavily relies on it for efficency
+  #   only after if is DT because heavily relies on it for efficiency
   #   only after Id is character because needed to compare to data.transaction Id
   check_err_msg(check_userinput_datanocov_datastaticcov(clv.data = clv.data, dt.data.static.cov = data.cov.life,  names.cov = names.cov.life, name.of.covariate="Lifetime"))
   check_err_msg(check_userinput_datanocov_datastaticcov(clv.data = clv.data, dt.data.static.cov = data.cov.trans,  names.cov = names.cov.trans, name.of.covariate="Transaction"))
@@ -70,13 +70,14 @@ SetStaticCovariates <- function(clv.data, data.cov.life, data.cov.trans, names.c
 
   # Make cov data --------------------------------------------------------------------------
   #   keep numbers, char/factors to dummies
-  l.covs.life  <- convert_userinput_covariatedata_dummies(dt.cov.data=data.cov.life,  names.cov=names.cov.life)
-  l.covs.trans <- convert_userinput_covariatedata_dummies(dt.cov.data=data.cov.trans, names.cov=names.cov.trans)
+  #   input data.cov.X is renamed by ref to legal names
+  l.covs.life  <- convert_userinput_covariatedata(dt.cov.data=data.cov.life,  names.cov=names.cov.life)
+  l.covs.trans <- convert_userinput_covariatedata(dt.cov.data=data.cov.trans, names.cov=names.cov.trans)
 
   data.cov.life  <- l.covs.life$data.cov
   data.cov.trans <- l.covs.trans$data.cov
-  names.cov.data.life  <- l.covs.life$names.cov
-  names.cov.data.trans <- l.covs.trans$names.cov
+  names.cov.data.life  <- l.covs.life$final.names.cov
+  names.cov.data.trans <- l.covs.trans$final.names.cov
 
   setkeyv(data.cov.life,  cols = "Id")
   setkeyv(data.cov.trans, cols = "Id")

--- a/tests/testthat/helper_testthat_runability_staticcov.R
+++ b/tests/testthat/helper_testthat_runability_staticcov.R
@@ -191,7 +191,7 @@ fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor <- fu
 
 
 fct.testthat.runability.staticcov.works.with.illegal.cov.names <- function(method, data.apparelTrans, data.apparelStaticCov,
-                                                                           clv.data.holdout, clv.data.no.holdout, clv.newdata.nohold, clv.newdata.withhold,
+                                                                           clv.data.holdout, clv.data.no.holdout,
                                                                            DERT.not.implemented, names.params.model){
 
   test_that("Works with static covs that have syntactically illegal names", {
@@ -205,6 +205,13 @@ fct.testthat.runability.staticcov.works.with.illegal.cov.names <- function(metho
                                                                     estimation.split = 40,
                                                                     names.cov.life = new.names, names.cov.trans = new.names)
       expect_silent(fitted <- do.call(what = method, args = list(clv.data=clv.data.named, verbose = FALSE)))
+
+      # Newdata is created here because of different names
+      clv.newdata.nohold <- fct.helper.create.fake.newdata.staticcov(data.trans = data.apparelTrans, estimation.split = NULL,
+                                                                     names.cov = new.names)
+      clv.newdata.withhold <- fct.helper.create.fake.newdata.staticcov(data.trans = data.apparelTrans, estimation.split = 40,
+                                                                       names.cov = new.names)
+
       fct.helper.clvfittedtransactions.all.s3(clv.fitted = fitted,  full.names = c(names.params.model,
                                                                                    paste0("life.",make.names(new.names)),
                                                                                    paste0("trans.",make.names(new.names))),
@@ -212,9 +219,10 @@ fct.testthat.runability.staticcov.works.with.illegal.cov.names <- function(metho
                                               DERT.not.implemented = DERT.not.implemented)
     }
 
+    # Numbers
     fct.run.with.renamed.cov(new.names = c("84", "99"))
+    # With spaces
     fct.run.with.renamed.cov(new.names = c("Gen der", " Channel"))
-
   })
 }
 
@@ -277,96 +285,94 @@ fct.testthat.runability.staticcov <- function(name.model, method, start.params.m
   l.args.test.all.s3 <- list(full.names = names.params.all.free, clv.newdata.nohold = clv.newdata.nohold,
                              clv.newdata.withhold = clv.newdata.withhold, DERT.not.implemented = !has.DERT)
 
-  # # Common tests ------------------------------------------------------------------------------------------------------------
-  # fct.testthat.runability.clvfitted.out.of.the.box.no.hold(method = method, clv.data.noholdout = clv.data.cov.no.holdout,
-  #                                                          l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
-  # fct.testthat.runability.clvfitted.out.of.the.box.with.hold(method = method, clv.data.withholdout = clv.data.cov.holdout,
-  #                                                            l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
-  #
-  # fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.no.holdout)
-  # fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.holdout)
-  #
-  # # fct.testthat.runability.clvfitted.all.optimization.methods(method = method, clv.data = clv.data.cov.no.holdout,
-  # #                                                         expected.message = failed.optimization.methods.expected.message)
-  #
-  # # fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data=clv.data.cov.no.holdout
-  # #                                                                 l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
-  #
-  #
-  #
-  # # Static cov tests ------------------------------------------------------------------------------------------------------------
-  # fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.holdout,
-  #                                                                       start.params.model = start.params.model)
-  # fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.no.holdout,
-  #                                                                       start.params.model = start.params.model)
-  #
-  # fct.testthat.runability.staticcov.reduce.relevant.covariates.estimation(method = method, clv.data.holdout = clv.data.cov.holdout)
+  # Common tests ------------------------------------------------------------------------------------------------------------
+  fct.testthat.runability.clvfitted.out.of.the.box.no.hold(method = method, clv.data.noholdout = clv.data.cov.no.holdout,
+                                                           l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  fct.testthat.runability.clvfitted.out.of.the.box.with.hold(method = method, clv.data.withholdout = clv.data.cov.holdout,
+                                                             l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+
+  fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.no.holdout)
+  fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.holdout)
+
+  # fct.testthat.runability.clvfitted.all.optimization.methods(method = method, clv.data = clv.data.cov.no.holdout,
+  #                                                         expected.message = failed.optimization.methods.expected.message)
+
+  # fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data=clv.data.cov.no.holdout
+  #                                                                 l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+
+
+
+  # Static cov tests ------------------------------------------------------------------------------------------------------------
+  fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.holdout,
+                                                                        start.params.model = start.params.model)
+  fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.no.holdout,
+                                                                        start.params.model = start.params.model)
+
+  fct.testthat.runability.staticcov.reduce.relevant.covariates.estimation(method = method, clv.data.holdout = clv.data.cov.holdout)
 
   fct.testthat.runability.staticcov.works.with.illegal.cov.names(method = method, data.apparelTrans = data.apparelTrans, data.apparelStaticCov = data.apparelStaticCov,
                                                                  DERT.not.implemented = !has.DERT,
                                                                  clv.data.holdout = clv.data.cov.holdout,
-                                                                 clv.newdata.nohold = clv.newdata.nohold,
-                                                                 clv.newdata.withhold = clv.newdata.withhold,
                                                                  names.params.model = names(start.params.model))
 
 
-  # if(has.cor){
-  #   context(paste0("Runability - ",name.model," static cov - w/ Correlation"))
-  #
-  #   fct.testthat.runability.common.works.with.cor(method = method,
-  #                                                 DERT.not.implemented = !has.DERT,
-  #                                                 clv.data.holdout = clv.data.cov.holdout,
-  #                                                 clv.newdata.nohold = clv.newdata.nohold,
-  #                                                 clv.newdata.withhold = clv.newdata.withhold,
-  #                                                 names.params.model = names(start.params.model))
-  #
-  #   fct.testthat.runability.common.works.with.cor.start.params(method = method,
-  #                                                              DERT.not.implemented = !has.DERT,
-  #                                                              clv.data.holdout = clv.data.cov.holdout,
-  #                                                              clv.newdata.nohold = clv.newdata.nohold,
-  #                                                              clv.newdata.withhold = clv.newdata.withhold,
-  #                                                              names.params.model = names(start.params.model))
-  # }
-  #
-  # context(paste0("Runability - ",name.model," static cov - w/ Constraint"))
-  # fct.testthat.runability.staticcov.works.with.2.constraints(method = method,
-  #                                                            param.names.model = names(start.params.model),
-  #                                                            DERT.not.implemented = !has.DERT,
-  #                                                            clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                            clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  #
-  # fct.testthat.runability.staticcov.works.with.1.constraint.1.free(method = method,
-  #                                                                  param.names.model = names(start.params.model),
-  #                                                                  DERT.not.implemented = !has.DERT,
-  #                                                                  clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                                  clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  #
-  # context(paste0("Runability - ",name.model," static cov - w/ Regularization"))
-  # fct.testthat.runability.staticcov.works.with.regularization(method = method,
-  #                                                             param.names.model = names(start.params.model),
-  #                                                             DERT.not.implemented = !has.DERT,
-  #                                                             clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                             clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  #
-  # fct.testthat.runability.staticcov.works.with.0.lambdas(method = method,
-  #                                                        param.names.model = names(start.params.model),
-  #                                                        DERT.not.implemented = !has.DERT,
-  #                                                        clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                        clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  #
-  # context(paste0("Runability - ",name.model," static cov - w/ Combinations"))
-  # if(has.cor){
-  #   fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor(method = method,
-  #                                                                              model.param.names = names(start.params.model),
-  #                                                                              DERT.not.implemented = !has.DERT,
-  #                                                                              clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                                              clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  # }else{
-  #   fct.testthat.runability.staticcov.works.with.combined.interlayers.without.cor(method = method,
-  #                                                                                 model.param.names = names(start.params.model),
-  #                                                                                 DERT.not.implemented = !has.DERT,
-  #                                                                                 clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-  #                                                                                 clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  # }
+  if(has.cor){
+    context(paste0("Runability - ",name.model," static cov - w/ Correlation"))
+
+    fct.testthat.runability.common.works.with.cor(method = method,
+                                                  DERT.not.implemented = !has.DERT,
+                                                  clv.data.holdout = clv.data.cov.holdout,
+                                                  clv.newdata.nohold = clv.newdata.nohold,
+                                                  clv.newdata.withhold = clv.newdata.withhold,
+                                                  names.params.model = names(start.params.model))
+
+    fct.testthat.runability.common.works.with.cor.start.params(method = method,
+                                                               DERT.not.implemented = !has.DERT,
+                                                               clv.data.holdout = clv.data.cov.holdout,
+                                                               clv.newdata.nohold = clv.newdata.nohold,
+                                                               clv.newdata.withhold = clv.newdata.withhold,
+                                                               names.params.model = names(start.params.model))
+  }
+
+  context(paste0("Runability - ",name.model," static cov - w/ Constraint"))
+  fct.testthat.runability.staticcov.works.with.2.constraints(method = method,
+                                                             param.names.model = names(start.params.model),
+                                                             DERT.not.implemented = !has.DERT,
+                                                             clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                             clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+
+  fct.testthat.runability.staticcov.works.with.1.constraint.1.free(method = method,
+                                                                   param.names.model = names(start.params.model),
+                                                                   DERT.not.implemented = !has.DERT,
+                                                                   clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                                   clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+
+  context(paste0("Runability - ",name.model," static cov - w/ Regularization"))
+  fct.testthat.runability.staticcov.works.with.regularization(method = method,
+                                                              param.names.model = names(start.params.model),
+                                                              DERT.not.implemented = !has.DERT,
+                                                              clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                              clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+
+  fct.testthat.runability.staticcov.works.with.0.lambdas(method = method,
+                                                         param.names.model = names(start.params.model),
+                                                         DERT.not.implemented = !has.DERT,
+                                                         clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                         clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+
+  context(paste0("Runability - ",name.model," static cov - w/ Combinations"))
+  if(has.cor){
+    fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor(method = method,
+                                                                               model.param.names = names(start.params.model),
+                                                                               DERT.not.implemented = !has.DERT,
+                                                                               clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                                               clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  }else{
+    fct.testthat.runability.staticcov.works.with.combined.interlayers.without.cor(method = method,
+                                                                                  model.param.names = names(start.params.model),
+                                                                                  DERT.not.implemented = !has.DERT,
+                                                                                  clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                                                                  clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  }
 }
 

--- a/tests/testthat/helper_testthat_runability_staticcov.R
+++ b/tests/testthat/helper_testthat_runability_staticcov.R
@@ -189,6 +189,36 @@ fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor <- fu
   })
 }
 
+
+fct.testthat.runability.staticcov.works.with.illegal.cov.names <- function(method, data.apparelTrans, data.apparelStaticCov,
+                                                                           clv.data.holdout, clv.data.no.holdout, clv.newdata.nohold, clv.newdata.withhold,
+                                                                           DERT.not.implemented, names.params.model){
+
+  test_that("Works with static covs that have syntactically illegal names", {
+    skip_on_cran()
+    # skip_on_ci()
+    fct.run.with.renamed.cov <- function(new.names){
+      apparelStaticCov.named <- data.table::copy(data.apparelStaticCov)
+      data.table::setnames(apparelStaticCov.named, old = c("Gender", "Channel"), new=new.names)
+      clv.data.named <- fct.helper.create.clvdata.apparel.staticcov(data.apparelTrans = data.apparelTrans,
+                                                                    data.apparelStaticCov = apparelStaticCov.named,
+                                                                    estimation.split = 40,
+                                                                    names.cov.life = new.names, names.cov.trans = new.names)
+      expect_silent(fitted <- do.call(what = method, args = list(clv.data=clv.data.named, verbose = FALSE)))
+      fct.helper.clvfittedtransactions.all.s3(clv.fitted = fitted,  full.names = c(names.params.model,
+                                                                                   paste0("life.",make.names(new.names)),
+                                                                                   paste0("trans.",make.names(new.names))),
+                                              clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+                                              DERT.not.implemented = DERT.not.implemented)
+    }
+
+    fct.run.with.renamed.cov(new.names = c("84", "99"))
+    fct.run.with.renamed.cov(new.names = c("Gen der", " Channel"))
+
+  })
+}
+
+
 fct.helper.create.fake.newdata.staticcov <- function(data.trans, estimation.split, names.cov){
 
   # Create with new fake data and generally other names
@@ -212,16 +242,20 @@ fct.helper.create.fake.newdata.staticcov <- function(data.trans, estimation.spli
   return(clv.newdata)
 }
 
-fct.helper.create.clvdata.apparel.staticcov <- function(data.apparelTrans, data.apparelStaticCov, estimation.split){
+fct.helper.create.clvdata.apparel.staticcov <- function(data.apparelTrans, data.apparelStaticCov, estimation.split,
+                                                        names.cov.life = c("Gender", "Channel"), names.cov.trans = c("Gender", "Channel")){
+
   expect_silent(clv.data.apparel <- clvdata(data.transactions = data.apparelTrans, date.format = "ymd", time.unit = "W",
                                             estimation.split = estimation.split))
 
   expect_silent(clv.data.apparel    <- SetStaticCovariates(clv.data.apparel,
                                                            data.cov.life = data.apparelStaticCov, data.cov.trans = data.apparelStaticCov,
-                                                           names.cov.life = c("Gender", "Channel"), names.cov.trans = c("Gender", "Channel")))
+                                                           names.cov.life = names.cov.life, names.cov.trans = names.cov.trans))
 
   return(clv.data.apparel)
 }
+
+
 
 fct.testthat.runability.staticcov <- function(name.model, method, start.params.model, has.DERT, has.cor,
                                               data.apparelTrans, data.apparelStaticCov,
@@ -243,89 +277,96 @@ fct.testthat.runability.staticcov <- function(name.model, method, start.params.m
   l.args.test.all.s3 <- list(full.names = names.params.all.free, clv.newdata.nohold = clv.newdata.nohold,
                              clv.newdata.withhold = clv.newdata.withhold, DERT.not.implemented = !has.DERT)
 
-  # Common tests ------------------------------------------------------------------------------------------------------------
-  fct.testthat.runability.clvfitted.out.of.the.box.no.hold(method = method, clv.data.noholdout = clv.data.cov.no.holdout,
-                                                           l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
-  fct.testthat.runability.clvfitted.out.of.the.box.with.hold(method = method, clv.data.withholdout = clv.data.cov.holdout,
-                                                             l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  # # Common tests ------------------------------------------------------------------------------------------------------------
+  # fct.testthat.runability.clvfitted.out.of.the.box.no.hold(method = method, clv.data.noholdout = clv.data.cov.no.holdout,
+  #                                                          l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  # fct.testthat.runability.clvfitted.out.of.the.box.with.hold(method = method, clv.data.withholdout = clv.data.cov.holdout,
+  #                                                            l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  #
+  # fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.no.holdout)
+  # fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.holdout)
+  #
+  # # fct.testthat.runability.clvfitted.all.optimization.methods(method = method, clv.data = clv.data.cov.no.holdout,
+  # #                                                         expected.message = failed.optimization.methods.expected.message)
+  #
+  # # fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data=clv.data.cov.no.holdout
+  # #                                                                 l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  #
+  #
+  #
+  # # Static cov tests ------------------------------------------------------------------------------------------------------------
+  # fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.holdout,
+  #                                                                       start.params.model = start.params.model)
+  # fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.no.holdout,
+  #                                                                       start.params.model = start.params.model)
+  #
+  # fct.testthat.runability.staticcov.reduce.relevant.covariates.estimation(method = method, clv.data.holdout = clv.data.cov.holdout)
 
-  fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.no.holdout)
-  fct.testthat.runability.clvfitted.custom.model.start.params(method = method, start.params.model = start.params.model, clv.data = clv.data.cov.holdout)
-
-  # fct.testthat.runability.clvfitted.all.optimization.methods(method = method, clv.data = clv.data.cov.no.holdout,
-  #                                                         expected.message = failed.optimization.methods.expected.message)
-
-  # fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data=clv.data.cov.no.holdout
-  #                                                                 l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
+  fct.testthat.runability.staticcov.works.with.illegal.cov.names(method = method, data.apparelTrans = data.apparelTrans, data.apparelStaticCov = data.apparelStaticCov,
+                                                                 DERT.not.implemented = !has.DERT,
+                                                                 clv.data.holdout = clv.data.cov.holdout,
+                                                                 clv.newdata.nohold = clv.newdata.nohold,
+                                                                 clv.newdata.withhold = clv.newdata.withhold,
+                                                                 names.params.model = names(start.params.model))
 
 
-
-  # Static cov tests ------------------------------------------------------------------------------------------------------------
-  fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.holdout,
-                                                                        start.params.model = start.params.model)
-  fct.testthat.runability.staticcov.custom.model.covariate.start.params(method = method, clv.data = clv.data.cov.no.holdout,
-                                                                        start.params.model = start.params.model)
-
-  fct.testthat.runability.staticcov.reduce.relevant.covariates.estimation(method = method, clv.data.holdout = clv.data.cov.holdout)
-
-
-  if(has.cor){
-    context(paste0("Runability - ",name.model," static cov - w/ Correlation"))
-
-    fct.testthat.runability.common.works.with.cor(method = method,
-                                                  DERT.not.implemented = !has.DERT,
-                                                  clv.data.holdout = clv.data.cov.holdout,
-                                                  clv.newdata.nohold = clv.newdata.nohold,
-                                                  clv.newdata.withhold = clv.newdata.withhold,
-                                                  names.params.model = names(start.params.model))
-
-    fct.testthat.runability.common.works.with.cor.start.params(method = method,
-                                                               DERT.not.implemented = !has.DERT,
-                                                               clv.data.holdout = clv.data.cov.holdout,
-                                                               clv.newdata.nohold = clv.newdata.nohold,
-                                                               clv.newdata.withhold = clv.newdata.withhold,
-                                                               names.params.model = names(start.params.model))
-  }
-
-  context(paste0("Runability - ",name.model," static cov - w/ Constraint"))
-  fct.testthat.runability.staticcov.works.with.2.constraints(method = method,
-                                                             param.names.model = names(start.params.model),
-                                                             DERT.not.implemented = !has.DERT,
-                                                             clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                             clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-
-  fct.testthat.runability.staticcov.works.with.1.constraint.1.free(method = method,
-                                                                   param.names.model = names(start.params.model),
-                                                                   DERT.not.implemented = !has.DERT,
-                                                                   clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                                   clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-
-  context(paste0("Runability - ",name.model," static cov - w/ Regularization"))
-  fct.testthat.runability.staticcov.works.with.regularization(method = method,
-                                                              param.names.model = names(start.params.model),
-                                                              DERT.not.implemented = !has.DERT,
-                                                              clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                              clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-
-  fct.testthat.runability.staticcov.works.with.0.lambdas(method = method,
-                                                         param.names.model = names(start.params.model),
-                                                         DERT.not.implemented = !has.DERT,
-                                                         clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                         clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-
-  context(paste0("Runability - ",name.model," static cov - w/ Combinations"))
-  if(has.cor){
-    fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor(method = method,
-                                                                               model.param.names = names(start.params.model),
-                                                                               DERT.not.implemented = !has.DERT,
-                                                                               clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                                               clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  }else{
-    fct.testthat.runability.staticcov.works.with.combined.interlayers.without.cor(method = method,
-                                                                                  model.param.names = names(start.params.model),
-                                                                                  DERT.not.implemented = !has.DERT,
-                                                                                  clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
-                                                                                  clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
-  }
+  # if(has.cor){
+  #   context(paste0("Runability - ",name.model," static cov - w/ Correlation"))
+  #
+  #   fct.testthat.runability.common.works.with.cor(method = method,
+  #                                                 DERT.not.implemented = !has.DERT,
+  #                                                 clv.data.holdout = clv.data.cov.holdout,
+  #                                                 clv.newdata.nohold = clv.newdata.nohold,
+  #                                                 clv.newdata.withhold = clv.newdata.withhold,
+  #                                                 names.params.model = names(start.params.model))
+  #
+  #   fct.testthat.runability.common.works.with.cor.start.params(method = method,
+  #                                                              DERT.not.implemented = !has.DERT,
+  #                                                              clv.data.holdout = clv.data.cov.holdout,
+  #                                                              clv.newdata.nohold = clv.newdata.nohold,
+  #                                                              clv.newdata.withhold = clv.newdata.withhold,
+  #                                                              names.params.model = names(start.params.model))
+  # }
+  #
+  # context(paste0("Runability - ",name.model," static cov - w/ Constraint"))
+  # fct.testthat.runability.staticcov.works.with.2.constraints(method = method,
+  #                                                            param.names.model = names(start.params.model),
+  #                                                            DERT.not.implemented = !has.DERT,
+  #                                                            clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                            clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  #
+  # fct.testthat.runability.staticcov.works.with.1.constraint.1.free(method = method,
+  #                                                                  param.names.model = names(start.params.model),
+  #                                                                  DERT.not.implemented = !has.DERT,
+  #                                                                  clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                                  clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  #
+  # context(paste0("Runability - ",name.model," static cov - w/ Regularization"))
+  # fct.testthat.runability.staticcov.works.with.regularization(method = method,
+  #                                                             param.names.model = names(start.params.model),
+  #                                                             DERT.not.implemented = !has.DERT,
+  #                                                             clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                             clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  #
+  # fct.testthat.runability.staticcov.works.with.0.lambdas(method = method,
+  #                                                        param.names.model = names(start.params.model),
+  #                                                        DERT.not.implemented = !has.DERT,
+  #                                                        clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                        clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  #
+  # context(paste0("Runability - ",name.model," static cov - w/ Combinations"))
+  # if(has.cor){
+  #   fct.testthat.runability.staticcov.works.with.combined.interlayers.with.cor(method = method,
+  #                                                                              model.param.names = names(start.params.model),
+  #                                                                              DERT.not.implemented = !has.DERT,
+  #                                                                              clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                                              clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  # }else{
+  #   fct.testthat.runability.staticcov.works.with.combined.interlayers.without.cor(method = method,
+  #                                                                                 model.param.names = names(start.params.model),
+  #                                                                                 DERT.not.implemented = !has.DERT,
+  #                                                                                 clv.newdata.nohold = clv.newdata.nohold, clv.newdata.withhold = clv.newdata.withhold,
+  #                                                                                 clv.data.holdout = clv.data.cov.holdout, clv.data.no.holdout = clv.data.cov.no.holdout)
+  # }
 }
 

--- a/tests/testthat/test_correctness_clvdata_setstaticcov.R
+++ b/tests/testthat/test_correctness_clvdata_setstaticcov.R
@@ -181,6 +181,30 @@ test_that("Keeps numeric as numeric - with categories", {
 })
 
 
+# Covariate names are legal --------------------------------------------------------
+test_that("Cov data column names are changed to syntactically valid names", {
+  skip_on_cran()
+  fct.test.data.cols.renamed <- function(new.names){
+    apparelStaticCov.named <- data.table::copy(apparelStaticCov)
+    data.table::setnames(apparelStaticCov.named, old = c("Gender", "Channel"), new=new.names)
+    expect_silent(static.cov <- SetStaticCovariates(clv.data = clv.data.apparel.withhold,
+                                                    data.cov.life  = apparelStaticCov.named, names.cov.life = new.names,
+                                                    data.cov.trans = apparelStaticCov.named, names.cov.trans = new.names))
+    expect_true(setequal(colnames(static.cov@data.cov.life),
+                         c("Id", make.names(new.names))))
+    expect_true(setequal(colnames(static.cov@data.cov.trans),
+                         c("Id", make.names(new.names))))
+  }
+
+  # Previously failed for numeric names and spaces
+  fct.test.data.cols.renamed(c("1", "2"))
+  fct.test.data.cols.renamed(c("1abc", "2xyz"))
+  fct.test.data.cols.renamed(c("Gender ", "Chan nel"))
+  fct.test.data.cols.renamed(c(" Gender", "Channe l"))
+
+})
+
+
 # Copied ---------------------------------------------------------------------------
 test_that("Cov data was properly copied", {
   skip_on_cran()


### PR DESCRIPTION
Cannot estimate models if cov names are syntactically invalid (contain spaces, start with number) etc