### PR TITLE
PNBD DERT numerical stability

### DIFF
--- a/src/clv_vectorized.cpp
+++ b/src/clv_vectorized.cpp
@@ -111,6 +111,22 @@ arma::vec vec_x_hyp1F1(const double a, const double b, const arma::vec& vX){
 }
 
 
+// vec_kummerU ----------------------------------------------------
+arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX){
+
+  // Do not abort in case of error
+  gsl_set_error_handler_off();
+
+  arma::vec vRes(vX);
+
+  arma::uword n = vX.n_elem;
+  for(arma::uword i = 0; i<n; i++)
+    vRes(i) = gsl_sf_hyperg_U(a, b, vX(i));
+
+  return(vRes);
+}
+
+
 // vec_pow --------------------------------------------------------
 //    element-by-element pow of the two given vectors
 arma::vec vec_pow(const arma::vec& vA, const arma::vec& vP){

--- a/src/clv_vectorized.cpp
+++ b/src/clv_vectorized.cpp
@@ -90,27 +90,6 @@ arma::vec vec_hyp2F1(const arma::vec& vA, const arma::vec& vB, const arma::vec& 
 }
 
 
-
-// vec_x_hyp1F1 ----------------------------------------------------
-//    a, b:     scalars
-//    X:        vector
-//
-//    hypergeom1F1(double a, double b, double x);
-arma::vec vec_x_hyp1F1(const double a, const double b, const arma::vec& vX){
-
-  // Do not abort in case of error
-  gsl_set_error_handler_off();
-
-  arma::vec vRes(vX);
-
-  arma::uword n = vX.n_elem;
-  for(arma::uword i = 0; i<n; i++)
-    vRes(i) = gsl_sf_hyperg_1F1(a, b, vX(i));
-
-  return(vRes);
-}
-
-
 // vec_kummerU ----------------------------------------------------
 arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX){
 

--- a/src/clv_vectorized.h
+++ b/src/clv_vectorized.h
@@ -20,6 +20,8 @@ arma::vec vec_hyp2F1(const arma::vec& vA, const arma::vec& vB, const arma::vec& 
 //    X as vector, a, b as scalars
 arma::vec vec_x_hyp1F1(double a, double b, const arma::vec& vX);
 
+arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX);
+
 arma::vec vec_pow(const arma::vec& vA, const arma::vec& vP);
 
 arma::vec vec_fill(const double number, const double repetitions);

--- a/src/clv_vectorized.h
+++ b/src/clv_vectorized.h
@@ -16,10 +16,6 @@ namespace clv{
 //    all inputs as vectors
 arma::vec vec_hyp2F1(const arma::vec& vA, const arma::vec& vB, const arma::vec& vC, const arma::vec& vX);
 
-// vec_x_hyp1F1
-//    X as vector, a, b as scalars
-arma::vec vec_x_hyp1F1(double a, double b, const arma::vec& vX);
-
 arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX);
 
 arma::vec vec_pow(const arma::vec& vA, const arma::vec& vP);

--- a/src/pnbd.cpp
+++ b/src/pnbd.cpp
@@ -164,11 +164,7 @@ arma::vec pnbd_DERT_ind(const double r,
   arma::vec vLL = pnbd_LL_ind(r, s, vAlpha_i, vBeta_i, vX, vT_x, vT_cal);
 
   arma::vec vZ = continuous_discount_factor * (vBeta_i + vT_cal);
-
-  arma::vec vPart1 = (arma::pow(vZ, 1-s) / (s-1))  % clv::vec_x_hyp1F1(1, 2-s, vZ);
-  arma::vec vPart2 = std::tgamma(1-s) * clv::vec_x_hyp1F1(s, s, vZ);
-  //
-  arma::vec vTerm = vPart1 + vPart2;
+  arma::vec vTerm = clv::vec_x_kummerU(s, s, vZ);
 
   arma::vec vDERT = arma::exp(
     r * arma::log(vAlpha_i)

--- a/src/pnbd.cpp
+++ b/src/pnbd.cpp
@@ -164,7 +164,11 @@ arma::vec pnbd_DERT_ind(const double r,
   arma::vec vLL = pnbd_LL_ind(r, s, vAlpha_i, vBeta_i, vX, vT_x, vT_cal);
 
   arma::vec vZ = continuous_discount_factor * (vBeta_i + vT_cal);
-  arma::vec vTerm = clv::vec_x_kummerU(s, s, vZ);
+
+  arma::vec vPart1 = (arma::pow(vZ, 1-s) / (s-1))  % clv::vec_x_hyp1F1(1, 2-s, vZ);
+  arma::vec vPart2 = std::tgamma(1-s) * clv::vec_x_hyp1F1(s, s, vZ);
+  //
+  arma::vec vTerm = vPart1 + vPart2;
 
   arma::vec vDERT = arma::exp(
     r * arma::log(vAlpha_i)

--- a/tests/testthat/helper_s3_fitted_predict.R
+++ b/tests/testthat/helper_s3_fitted_predict.R
@@ -127,11 +127,14 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
   if(!DERT.not.implemented){
     test_that("Works with discount factor", {
       skip_on_cran()
-      expect_silent(dt.pred.1 <- predict(fitted.transactions, continuous.discount.factor = 0,    prediction.end = 6, verbose=FALSE))
+      expect_silent(dt.pred.1 <- predict(fitted.transactions, continuous.discount.factor = 0.001,prediction.end = 6, verbose=FALSE))
       expect_silent(dt.pred.2 <- predict(fitted.transactions, continuous.discount.factor = 0.06, prediction.end = 6, verbose=FALSE))
       expect_silent(dt.pred.3 <- predict(fitted.transactions, continuous.discount.factor = 0.99, prediction.end = 6, verbose=FALSE))
       expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
       expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
+      expect_true(dt.pred.1[, all(is.finite(DERT))])
+      expect_true(dt.pred.2[, all(is.finite(DERT))])
+      expect_true(dt.pred.3[, all(is.finite(DERT))])
     })
   }
 

--- a/tests/testthat/test_correctness_pnbd.R
+++ b/tests/testthat/test_correctness_pnbd.R
@@ -44,6 +44,20 @@ test_that("Can calculate numerically stable PAlive that produced NaNs in previou
 
 
 
+context("Correctness - PNBD nocov - DERT")
+
+test_that("Higher discount factor leads to smaller DERT", {
+  skip_on_cran()
+  expect_silent(p.cdnow <- pnbd(fct.helper.create.clvdata.cdnow(cdnow), verbose = FALSE))
+  expect_silent(dt.pred.1 <- predict(p.cdnow, continuous.discount.factor = 0.001,prediction.end = 6, verbose=FALSE))
+  expect_silent(dt.pred.2 <- predict(p.cdnow, continuous.discount.factor = 0.06, prediction.end = 6, verbose=FALSE))
+  expect_silent(dt.pred.3 <- predict(p.cdnow, continuous.discount.factor = 0.99, prediction.end = 6, verbose=FALSE))
+
+  expect_true(all(dt.pred.1$DERT > dt.pred.2$DERT))
+  expect_true(all(dt.pred.2$DERT > dt.pred.3$DERT))
+})
+
+
 # Dyncov ---------------------------------------------------------------------------------------
 fct.testthat.correctness.dyncov(data.apparelTrans=apparelTrans, data.apparelDynCov=apparelDynCov)
 


### PR DESCRIPTION
Use the gsl's implementation of the confluent hypergeometric function of the second kind instead of the currently used two-part representation involving the hyp1F1. See #171 