### PR TITLE
Draw other models in same plot

### DIFF
--- a/R/f_clvdata_inputchecks.R
+++ b/R/f_clvdata_inputchecks.R
@@ -9,7 +9,7 @@ check_err_msg <- function(err.msg){
   if(!is.logical(b))
     return(paste0("The parameter ", var.name, " needs to be of type logical (True/False)!"))
   if(length(b)>1)
-    err.msg <- c(err.msg, paste0("The parameter ", var.name, " can only contain a single element!"))
+    err.msg <- c(err.msg, paste0("The parameter ", var.name, " can only contain 1 element!"))
   if(anyNA(b))
     err.msg <- c(err.msg, paste0("The parameter ", var.name, " cannot be NA!"))
   return(err.msg)

--- a/R/f_clvdata_inputchecks.R
+++ b/R/f_clvdata_inputchecks.R
@@ -15,18 +15,21 @@ check_err_msg <- function(err.msg){
   return(err.msg)
 }
 
-.check_userinput_single_character <- function(char, var.name){
+.check_userinput_charactervec <- function(char, var.name, n){
   err.msg <- c()
+
   if(!is.character(char))
     return(paste0(var.name, " needs to be of type character (text)!"))
-  if(length(char) != 1)
-    err.msg <- c(err.msg, paste0(var.name, " must contain exactly one single element!"))
+  if(length(char) != n)
+    err.msg <- c(err.msg, paste0(var.name, " must contain exactly ", n, " element(s)!"))
   if(anyNA(char))
     err.msg <- c(err.msg, paste0(var.name, " may not contain any NA!"))
+
   if(length(err.msg) == 0){
     # is non empty vec, but check is not no text ("")
-    if(nchar(char[[1]]) == 0)
-      err.msg <- c(err.msg, paste0(var.name, " may not be empty text!"))
+    if(any(sapply(char, nchar) == 0)){
+      err.msg <- c(err.msg, paste0(var.name, " may not contain elements which are empty text!"))
+    }
   }
 
   return(err.msg)
@@ -143,7 +146,7 @@ check_userinput_datanocov_columnname <- function(name.col, data){
   if(is.null(name.col))
     return("Column names cannot be NULL!") #return already as NULL will break code
 
-  err.msg <- .check_userinput_single_character(char=name.col, var.name="Column names")
+  err.msg <- .check_userinput_charactervec(char=name.col, var.name="Column names", n=1)
 
   # check if column is exactly in data
   if(length(err.msg) == 0)
@@ -158,8 +161,7 @@ check_userinput_datanocov_timeunit <- function(time.unit){
   if(is.null(time.unit))
     return("Time unit cannot be NULL!") #return already as NULL will break code
 
-  err.msg <- .check_userinput_single_character(char=time.unit,
-                                               var.name = "time.unit")
+  err.msg <- .check_userinput_charactervec(char=time.unit, var.name = "time.unit", n=1)
 
 
   # use pmatch to match the input againts the possible time units

--- a/R/f_clvfitted_inputchecks.R
+++ b/R/f_clvfitted_inputchecks.R
@@ -316,3 +316,24 @@ check_user_data_othermodels <- function(other.models){
 }
 
 
+check_user_data_label <- function(label, other.models){
+  if(is.null(label)){
+    # null is allowed = std. model name(s)
+    return(c())
+  }
+  if(length(other.models)==0){
+      return(.check_userinput_charactervec(char=label, var.name="label", n=1))
+  }else{
+
+    # requires names for main and all other models
+    err.msg <- .check_userinput_charactervec(char=label, var.name="label", n=1+length(other.models))
+    if(length(err.msg)){
+      return(err.msg)
+    }
+
+    if(any(duplicated(label))){
+      err.msg <- c(err.msg, "Parameter label may not contain any duplicates!")
+    }
+    return(err.msg)
+  }
+}

--- a/R/f_clvfitted_inputchecks.R
+++ b/R/f_clvfitted_inputchecks.R
@@ -300,3 +300,19 @@ check_user_data_containsspendingdata <- function(clv.data){
 
   return(err.msg)
 }
+
+check_user_data_othermodels <- function(other.models){
+  if(!is.list(other.models)){
+    return("Parameter other.models has to be a list of fitted transaction models!")
+  }
+
+  # each element in list is a transaction model
+
+  if(!all(sapply(other.models, is, class2 = "clv.fitted.transactions"))){
+    return("All elements in 'other.models' have to be fitted transaction models, e.g the output of pnbd(), bgnbd(), or ggomnbd()!")
+  }
+
+  return(c())
+}
+
+

--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -37,7 +37,7 @@ setMethod(f = "clv.controlflow.predict.check.inputs", signature = signature(clv.
       }else{
         # Is logical
         if(length(predict.spending)>1)
-          err.msg <- c(err.msg, paste0("The parameter predict.spending can only contain a single element!"))
+          err.msg <- c(err.msg, paste0("The parameter predict.spending can only contain 1 element!"))
         if(anyNA(predict.spending))
           err.msg <- c(err.msg, paste0("The parameter predict.spending cannot be NA!"))
       }

--- a/R/f_interface_clvdata.R
+++ b/R/f_interface_clvdata.R
@@ -134,7 +134,7 @@ clvdata <- function(data.transactions, date.format, time.unit, estimation.split=
 
   err.msg <- c(err.msg, check_userinput_datanocov_timeunit(time.unit=time.unit))
 
-  err.msg <- c(err.msg, .check_userinput_single_character(char=date.format, var.name = "date.format"))
+  err.msg <- c(err.msg, .check_userinput_charactervec(char=date.format, var.name = "date.format", n=1))
   err.msg <- c(err.msg, check_userinput_datanocov_estimationsplit(estimation.split=estimation.split, date.format=date.format))
   check_err_msg(err.msg)
 

--- a/R/f_s3generics_clvdata_plot.R
+++ b/R/f_s3generics_clvdata_plot.R
@@ -254,7 +254,7 @@ clv.data.plot.add.default.theme <- function(p, custom=list()){
 
 clv.data.plot.tracking <- function(x, prediction.end, cumulative, plot, verbose, ...){
 
-  period.until <- period.num <- NULL
+  period.until <- period.num <- value <- NULL
 
   # This is nearly the same as plot.clv
   #   However, creating a single plotting controlflow leads to all kinds of side effects and special cases.
@@ -318,8 +318,9 @@ clv.data.plot.tracking <- function(x, prediction.end, cumulative, plot, verbose,
   dt.plot[]
 
   # Only if needed
-  if(!plot)
+  if(!plot){
     return(dt.plot)
+  }
 
   # Plot table with formatting, label etc
   p <- clv.controlflow.plot.tracking.base(dt.plot = dt.plot, clv.data = x,
@@ -407,7 +408,7 @@ clv.data.plot.barplot.frequency <- function(clv.data, count.repeat.trans, count.
   err.msg <- c()
   err.msg <- c(err.msg, .check_user_data_single_boolean(b=count.repeat.trans, var.name="count.repeat.trans"))
   err.msg <- c(err.msg, .check_user_data_single_boolean(b=count.remaining,    var.name="count.remaining"))
-  err.msg <- c(err.msg, .check_userinput_single_character(char=label.remaining, var.name="label.remaining"))
+  err.msg <- c(err.msg, .check_userinput_charactervec(char=label.remaining, var.name="label.remaining", n=1))
   err.msg <- c(err.msg, check_user_data_emptyellipsis(...))
   check_err_msg(err.msg) # count.repeat.trans has to be checked first
   check_err_msg(check_userinput_datanocov_transbins(trans.bins=trans.bins, count.repeat.trans=count.repeat.trans))

--- a/R/f_s3generics_clvdata_plot.R
+++ b/R/f_s3generics_clvdata_plot.R
@@ -322,8 +322,8 @@ clv.data.plot.tracking <- function(x, prediction.end, cumulative, plot, verbose,
     return(dt.plot)
 
   # Plot table with formatting, label etc
-  line.colors <- setNames(object = "black", nm = label.transactions)
-  p <- clv.controlflow.plot.tracking.base(dt.plot = dt.plot, clv.data = x, line.colors = line.colors)
+  p <- clv.controlflow.plot.tracking.base(dt.plot = dt.plot, clv.data = x,
+                                          color.mapping = setNames(object = "black", nm = label.transactions))
   p <- p + theme(legend.position = "none")
   return(p)
 }

--- a/R/f_s3generics_clvdata_plot.R
+++ b/R/f_s3generics_clvdata_plot.R
@@ -86,15 +86,16 @@
 #' which contains some of the following columns:
 #' \item{Id}{Customer Id}
 #' \item{period.until}{The timepoint that marks the end (up until and including) of the period to which the data in this row refers.}
-#' \item{Number of Repeat Transactions}{The number of actual repeat transactions in the period that ends at \code{period.until}.}
 #' \item{Spending}{Spending as defined by parameter \code{mean.spending}.}
 #' \item{mean.interpurchase.time}{Mean number of periods between transactions per customer,
 #' excluding customers with no repeat-transactions.}
 #' \item{num.transactions}{The number of (repeat) transactions, depending on \code{count.repeat.trans}.}
 #' \item{num.customers}{The number of customers.}
 #' \item{type}{"timings": Which purpose the value in this row is used for.}
-#' \item{variable}{"timings": Coordinate (x or y) for which to use the value in this row for.}
-#' \item{value}{"timings": Date or numeric (stored as string)}
+#' \item{variable}{"tracking": The number of actual repeat transactions in the period that ends at \code{period.until}.\cr
+#'                 "timings": Coordinate (x or y) for which to use the value in this row for.}
+#' \item{value}{"timings":  Date or numeric (stored as string) \cr
+#'              "tracking": numeric}
 #'
 #'
 #' @examples

--- a/R/f_s3generics_clvdata_plot.R
+++ b/R/f_s3generics_clvdata_plot.R
@@ -306,7 +306,10 @@ clv.data.plot.tracking <- function(x, prediction.end, cumulative, plot, verbose,
   #   To be sure to have all dates, merge data on original dates
   dt.dates.expectation[, period.num := NULL]
   dt.dates.expectation[dt.repeat.trans, (label.transactions) := get(label.transactions), on="period.until"]
-  dt.plot <- dt.dates.expectation
+  dt.plot <- melt(dt.dates.expectation, id.vars="period.until")
+
+  # last period often has NA as it marks the full span of the period
+  dt.plot <- dt.plot[!is.na(value)]
 
   # data.table does not print when returned because it is returned directly after last [:=]
   # " if a := is used inside a function with no DT[] before the end of the function, then the next
@@ -320,7 +323,7 @@ clv.data.plot.tracking <- function(x, prediction.end, cumulative, plot, verbose,
 
   # Plot table with formatting, label etc
   line.colors <- setNames(object = "black", nm = label.transactions)
-  p <- clv.controlflow.plot.make.plot(dt.data = dt.plot, clv.data = x, line.colors = line.colors)
+  p <- clv.controlflow.plot.tracking.base(dt.plot = dt.plot, clv.data = x, line.colors = line.colors)
   p <- p + theme(legend.position = "none")
   return(p)
 }

--- a/R/f_s3generics_clvfittedtransactions_plot.R
+++ b/R/f_s3generics_clvfittedtransactions_plot.R
@@ -191,19 +191,8 @@ plot.clv.fitted.transactions <- function (x,
   err.msg <- c(err.msg, check_user_data_othermodels(other.models=other.models))
   err.msg <- c(err.msg, check_user_data_emptyellipsis(...))
   check_err_msg(err.msg)
+  check_err_msg(check_user_data_label(label=label, other.models=other.models))
 
-  if(length(other.models)==0){
-    if(!is.null(label)){ # null is allowed = std. model name
-      check_err_msg(.check_userinput_charactervec(char=label, var.name="label", n=1))
-    }else{
-      label <- x@clv.model@name.model
-    }
-  }else{
-    # names for main and all other models
-    if(!is.null(label)){
-      check_err_msg(.check_userinput_charactervec(char=label, var.name="label", n=1+length(other.models)))
-    }
-  }
 
 
   # Newdata ------------------------------------------------------------------------------------------------
@@ -287,6 +276,9 @@ clv.fitted.transactions.plot.tracking <- function(x, other.models, newdata, pred
                                     plot=plot, label.line=label, verbose=verbose)
 
   if(length(other.models) == 0){
+    if(length(label) == 0){
+      label <- x@clv.model@name.model
+    }
 
     dt.plot <- clv.fitted.transactions.plot.tracking.get.data(
       x=x, prediction.end = prediction.end, cumulative=cumulative, label=label, transactions=transactions, verbose=verbose)
@@ -403,6 +395,9 @@ clv.fitted.transactions.plot.barplot.pmf <- function(x, newdata, other.models, t
   check_err_msg(.check_user_data_single_boolean(b=calculate.remaining, var.name="calculate.remaining"))
 
   if(length(other.models) == 0){
+    if(length(label) == 0){
+      label <- x@clv.model@name.model
+    }
 
     dt.plot <- clv.fitted.transactions.plot.barplot.pmf.get.data(
       x=x, trans.bins = trans.bins, calculate.remaining=calculate.remaining, label.remaining = label.remaining, transactions = transactions)
@@ -519,7 +514,7 @@ clv.fitted.transactions.plot.barplot.pmf.get.data <- function(x, trans.bins, cal
 }
 
 
-
+# other.models -----------------------------------------------------------------------------------------------
 clv.fitted.transactions.plot.multiple.models.prepare.label <- function(label, main.model, other.models){
 
   # create labels from model's name if missing

--- a/R/f_s3generics_clvfittedtransactions_plot.R
+++ b/R/f_s3generics_clvfittedtransactions_plot.R
@@ -3,6 +3,7 @@
 #' @param x The fitted transaction model for which to produce diagnostic plots
 #' @param which Which plot to produce, either "tracking" or "pmf". May be abbreviated but only one may be selected. Defaults to "tracking".
 #' @param other.models List of fitted transaction models to plot. List names are used as colors, standard colors are chosen if unnamed (see examples).
+#' The \code{clv.data} object stored in each model is used if no \code{newdata} is given.
 #'
 #' @param cumulative "tracking": Whether the cumulative expected (and actual) transactions should be plotted.
 #' @templateVar prefix "tracking":

--- a/man/plot.clv.data.Rd
+++ b/man/plot.clv.data.Rd
@@ -72,15 +72,16 @@ Depending on which plot was selected, this is a \code{data.table}
 which contains some of the following columns:
 \item{Id}{Customer Id}
 \item{period.until}{The timepoint that marks the end (up until and including) of the period to which the data in this row refers.}
-\item{Number of Repeat Transactions}{The number of actual repeat transactions in the period that ends at \code{period.until}.}
 \item{Spending}{Spending as defined by parameter \code{mean.spending}.}
 \item{mean.interpurchase.time}{Mean number of periods between transactions per customer,
 excluding customers with no repeat-transactions.}
 \item{num.transactions}{The number of (repeat) transactions, depending on \code{count.repeat.trans}.}
 \item{num.customers}{The number of customers.}
 \item{type}{"timings": Which purpose the value in this row is used for.}
-\item{variable}{"timings": Coordinate (x or y) for which to use the value in this row for.}
-\item{value}{"timings": Date or numeric (stored as string)}
+\item{variable}{"tracking": The number of actual repeat transactions in the period that ends at \code{period.until}.\cr
+                "timings": Coordinate (x or y) for which to use the value in this row for.}
+\item{value}{"timings":  Date or numeric (stored as string) \cr
+             "tracking": numeric}
 }
 \description{
 Depending on the value of parameter \code{which}, one of the following plots will be produced.

--- a/man/plot.clv.fitted.transactions.Rd
+++ b/man/plot.clv.fitted.transactions.Rd
@@ -58,7 +58,8 @@
 \item{label.remaining}{"pmf": Label for the last bar, if \code{calculate.remaining=TRUE}.}
 
 \item{newdata}{An object of class clv.data for which the plotting should be made with the fitted model.
-If none or NULL is given, the plot is made for the data on which the model was fit.}
+If none or NULL is given, the plot is made for the data on which the model was fit.
+If \code{other.models} was specified, the data in each model is replaced with \code{newdata}.}
 
 \item{transactions}{Whether the actual observed repeat transactions should be plotted.}
 

--- a/man/plot.clv.fitted.transactions.Rd
+++ b/man/plot.clv.fitted.transactions.Rd
@@ -9,6 +9,7 @@
 \method{plot}{clv.fitted.transactions}(
   x,
   which = c("tracking", "pmf"),
+  other.models = list(),
   prediction.end = NULL,
   cumulative = FALSE,
   trans.bins = 0:9,
@@ -25,6 +26,7 @@
 \S4method{plot}{clv.fitted.transactions}(
   x,
   which = c("tracking", "pmf"),
+  other.models = list(),
   prediction.end = NULL,
   cumulative = FALSE,
   trans.bins = 0:9,
@@ -43,11 +45,13 @@
 
 \item{which}{Which plot to produce, either "tracking" or "pmf". May be abbreviated but only one may be selected. Defaults to "tracking".}
 
+\item{other.models}{List of fitted transaction models to plot. List names are used as colors, standard colors are chosen if unnamed (see examples).}
+
 \item{prediction.end}{"tracking": Until what point in time to plot. This can be the number of periods (numeric) or a form of date/time object. See details.}
 
 \item{cumulative}{"tracking": Whether the cumulative expected (and actual) transactions should be plotted.}
 
-\item{trans.bins}{"pmf": Vector of positive integer numbers (>=0) indicating the number of repeat transactions (x axis) to plot.}
+\item{trans.bins}{"pmf": Vector of positive integer numbers (>=0) indicating the number of repeat transactions (x axis) to plot. Should contain 0 in nearly all cases as it refers to repeat-transactions.}
 
 \item{calculate.remaining}{"pmf": Whether the probability for the remaining number of transactions not in \code{trans.bins} should be calculated.}
 
@@ -58,7 +62,7 @@ If none or NULL is given, the plot is made for the data on which the model was f
 
 \item{transactions}{Whether the actual observed repeat transactions should be plotted.}
 
-\item{label}{Character string to label the model in the legend.}
+\item{label}{Character vector to label each model. If NULL, the model(s) internal name is used (see examples).}
 
 \item{plot}{Whether a plot is created or only the assembled data is returned.}
 
@@ -74,17 +78,21 @@ following columns:
 
 For the Tracking plot:
 \item{period.until}{The timepoint that marks the end (up until and including) of the period to which the data in this row refers.}
-\item{Actual}{The actual number of repeat transactions in the period that ends at \code{period.until}. Only if \code{transactions=TRUE}.}
-\item{"Name of Model" or "label"}{The value of the unconditional expectation for the period that ends on \code{period.until}.}
+\item{variable}{Type of variable that 'value' refers to. Either "model name" or "Actual" (if \code{transactions=TRUE}).}
+\item{value}{Depending on variable either (Actual) the actual number of repeat transactions in the period that ends at \code{period.until},
+or the unconditional expectation for the period that ends on \code{period.until} ("model name").}
 
 For the PMF plot:
-\item{num.transactions}{The number of observed repeat transactions in the estimation period (as ordered factor).}
-\item{actual.num.customers}{The actual number of customers which have the respective number of repeat transactions. Only if \code{transactions=TRUE}.}
-\item{expected.customers}{The number of customers which are expected to have the respective number of repeat transactions, as by the fitted model.}
+\item{num.transactions}{The number of repeat transactions in the estimation period (as ordered factor).}
+\item{variable}{Type of variable that 'value' refers to. Either "model name" or "Actual" (if \code{transactions=TRUE}).}
+\item{value}{Depending on variable either (Actual) the actual number of customers which have the respective number of repeat transactions,
+or the number of customers which are expected to have the respective number of repeat transactions, as by the fitted model ("model name").}
 }
 \description{
-Depending on the value of parameter which, one of the following plots will be produced.
+Depending on the value of parameter \code{which}, one of the following plots will be produced.
 See \code{\link[CLVTools:plot.clv.data]{plot.clv.data}} to plot more nuanced diagnostics for the transaction data only.
+For comparison, other models can be drawn into the same plot by specifying them in \code{other.models} (see examples).
+
 
 \subsection{Tracking Plot}{
 Plot the actual repeat transactions and overlay it with the repeat transaction as predicted
@@ -145,9 +153,10 @@ but the start of the first time unit after \code{prediction.end}.
 data("cdnow")
 
 # Fit ParetoNBD model on the CDnow data
-pnbd.cdnow <- pnbd(clvdata(cdnow, time.unit="w",
+clv.cdnow <- clvdata(cdnow, time.unit="w",
                            estimation.split=37,
-                           date.format="ymd"))
+                           date.format="ymd")
+pnbd.cdnow <- pnbd(clv.cdnow)
 
 ## TRACKING PLOT
 # Plot actual repeat transaction, overlayed with the
@@ -189,6 +198,20 @@ plot(pnbd.cdnow, which="pmf", trans.bins=0:15,
 plot(pnbd.cdnow, which="pmf", trans.bins=0:15,
      calculate.remaining=FALSE)
 
+## MODEL COMPARISON
+# compare vs bgnbd
+bgnbd.cdnow <- bgnbd(clv.cdnow)
+ggomnbd.cdnow <- ggomnbd(clv.cdnow)
+
+# specify colors as names of other.models
+# note that ggomnbd collapses into the pnbd on this dataset
+plot(pnbd.cdnow, cumulative=TRUE,
+     other.models=list(blue=bgnbd.cdnow, "#00ff00"=ggomnbd.cdnow))
+
+# specify names as label, using standard colors
+plot(pnbd.cdnow, which="pmf",
+     other.models=list(bgnbd.cdnow),
+     label=c("Pareto/NBD", "BG/NBD"))
 }
 
 }

--- a/man/plot.clv.fitted.transactions.Rd
+++ b/man/plot.clv.fitted.transactions.Rd
@@ -45,7 +45,8 @@
 
 \item{which}{Which plot to produce, either "tracking" or "pmf". May be abbreviated but only one may be selected. Defaults to "tracking".}
 
-\item{other.models}{List of fitted transaction models to plot. List names are used as colors, standard colors are chosen if unnamed (see examples).}
+\item{other.models}{List of fitted transaction models to plot. List names are used as colors, standard colors are chosen if unnamed (see examples).
+The \code{clv.data} object stored in each model is used if no \code{newdata} is given.}
 
 \item{prediction.end}{"tracking": Until what point in time to plot. This can be the number of periods (numeric) or a form of date/time object. See details.}
 

--- a/tests/testthat/helper_inputchecks_single_logical.R
+++ b/tests/testthat/helper_inputchecks_single_logical.R
@@ -39,7 +39,7 @@
   test_that("Fails for multiple", {
     for(illegal.arg in l.illegal.multiples){
       expect_error(do.call(fct, modifyList(l.std.args, setNames(list(param=illegal.arg), name.param))),
-                   regexp="single")
+                   regexp="1")
     }
   })
 }

--- a/tests/testthat/helper_s3_fitted.R
+++ b/tests/testthat/helper_s3_fitted.R
@@ -250,15 +250,14 @@ fct.helper.has.DERT <- function(clv.fitted.transactions){
 
 fct.helper.clvfittedtransactions.all.s3 <- function(clv.fitted, full.names,
                                                     clv.newdata.nohold, clv.newdata.withhold){
-  context(".fct.helper.clvfitted.all.s3")
   .fct.helper.clvfitted.all.s3(clv.fitted = clv.fitted, full.names = full.names)
-  context("fct.testthat.runability.clvfittedtransactions.plot")
+
   fct.testthat.runability.clvfittedtransactions.plot(clv.fitted = clv.fitted, clv.newdata.nohold=clv.newdata.nohold,
                                                      clv.newdata.withhold=clv.newdata.withhold)
-  context("fct.testthat.runability.clvfittedtransactions.predict")
+
   fct.testthat.runability.clvfittedtransactions.predict(fitted.transactions = clv.fitted, clv.newdata.nohold=clv.newdata.nohold,
                                                         clv.newdata.withhold=clv.newdata.withhold)
-  context("fct.testthat.runability.clvfittedtransactions.pmf")
+
   if(fct.helper.has.pmf(clv.fitted)){
     fct.testthat.runability.clvfittedtransactions.pmf(fitted.transactions=clv.fitted)
   }

--- a/tests/testthat/helper_s3_fitted.R
+++ b/tests/testthat/helper_s3_fitted.R
@@ -250,15 +250,15 @@ fct.helper.has.DERT <- function(clv.fitted.transactions){
 
 fct.helper.clvfittedtransactions.all.s3 <- function(clv.fitted, full.names,
                                                     clv.newdata.nohold, clv.newdata.withhold){
-
+  context(".fct.helper.clvfitted.all.s3")
   .fct.helper.clvfitted.all.s3(clv.fitted = clv.fitted, full.names = full.names)
-
+  context("fct.testthat.runability.clvfittedtransactions.plot")
   fct.testthat.runability.clvfittedtransactions.plot(clv.fitted = clv.fitted, clv.newdata.nohold=clv.newdata.nohold,
                                                      clv.newdata.withhold=clv.newdata.withhold)
-
+  context("fct.testthat.runability.clvfittedtransactions.predict")
   fct.testthat.runability.clvfittedtransactions.predict(fitted.transactions = clv.fitted, clv.newdata.nohold=clv.newdata.nohold,
                                                         clv.newdata.withhold=clv.newdata.withhold)
-
+  context("fct.testthat.runability.clvfittedtransactions.pmf")
   if(fct.helper.has.pmf(clv.fitted)){
     fct.testthat.runability.clvfittedtransactions.pmf(fitted.transactions=clv.fitted)
   }

--- a/tests/testthat/helper_s3_fitted_plot.R
+++ b/tests/testthat/helper_s3_fitted_plot.R
@@ -149,9 +149,9 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
       skip_on_cran()
 
       if(is(clv.fitted@clv.data@clv.time, "clv.time.date")){
-        tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::days(3)
+        tp.end <- clv.fitted@clv.data@clv.time@timepoint.estimation.end+lubridate::days(10)
       }else{
-        tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::hours(8)
+        tp.end <- clv.fitted@clv.data@clv.time@timepoint.estimation.end+lubridate::hours(10)
       }
 
       # prediction.end as character, Date, posix, numeric
@@ -285,22 +285,22 @@ fct.testthat.runability.clvfittedtransactions.plot.pmf <- function(clv.fitted, c
 }
 
 fct.testthat.runability.clvfittedtransactions.plot <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold){
-  # context("fct.testthat.runability.clvfittedtransactions.plot.common")
-  # fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="tracking")
+  context("fct.testthat.runability.clvfittedtransactions.plot.common")
+  fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="tracking")
   context("fct.testthat.runability.clvfittedtransactions.plot.tracking")
   fct.testthat.runability.clvfittedtransactions.plot.tracking(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
-  # context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
-  # fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="tracking")
-  # context("fct.helper.has.pmf")
-  # test_that("fct.helper.has.pmf", {expect_true(TRUE)})
-  # if(fct.helper.has.pmf(clv.fitted)){
-  #   context("fct.testthat.runability.clvfittedtransactions.plot.common")
-  #   fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="pmf")
-  #   context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
-  #   fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="pmf")
-  #   context("fct.testthat.runability.clvfittedtransactions.plot.pmf")
-  #   fct.testthat.runability.clvfittedtransactions.plot.pmf(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
-  # }
+  context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
+  fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="tracking")
+  context("fct.helper.has.pmf")
+  test_that("fct.helper.has.pmf", {expect_true(TRUE)})
+  if(fct.helper.has.pmf(clv.fitted)){
+    context("fct.testthat.runability.clvfittedtransactions.plot.common")
+    fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="pmf")
+    context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
+    fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="pmf")
+    context("fct.testthat.runability.clvfittedtransactions.plot.pmf")
+    fct.testthat.runability.clvfittedtransactions.plot.pmf(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
+  }
 }
 
 

--- a/tests/testthat/helper_s3_fitted_plot.R
+++ b/tests/testthat/helper_s3_fitted_plot.R
@@ -1,5 +1,4 @@
-fct.testthat.runability.clvfittedtransactions.plot.common <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold,
-                                                                      which){
+fct.testthat.runability.clvfittedtransactions.plot.common <- function(clv.fitted, which){
   test_that("Works with/without transactions=TRUE/FALSE",{
     skip_on_cran()
     expect_silent(plot(clv.fitted, which=which, transactions=TRUE, verbose=FALSE))
@@ -10,8 +9,43 @@ fct.testthat.runability.clvfittedtransactions.plot.common <- function(clv.fitted
     skip_on_cran()
     expect_silent(plot(clv.fitted, which=which, label="ABC", verbose=FALSE))
   })
-
 }
+
+fct.testthat.runability.clvfittedtransactions.plot.other.models <- function(clv.fitted, which, clv.fitted.other){
+
+  test_that("works with and without label",{
+    skip_on_cran()
+    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), label=c(), verbose=FALSE))
+    expect_silent(dt.plot <- plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), label=c("this", "again", "other"), verbose=FALSE, plot=FALSE))
+    expect_setequal(dt.plot[, unique(variable)], c("Actual", "this", "again", "other"))
+  })
+
+  test_that("works with and without colors",{
+    skip_on_cran()
+    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), verbose=FALSE))
+    expect_silent(plot(clv.fitted, which=which, other.models=list("blue"=clv.fitted, "#00ff00"=clv.fitted.other), verbose=FALSE))
+    # partly named other models
+    expect_silent(plot(clv.fitted, which=which, other.models=list(blue=clv.fitted, clv.fitted.other), verbose=FALSE))
+  })
+
+  test_that("works with newdata",{
+    skip_on_cran()
+    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), newdata=clv.fitted@clv.data, verbose=FALSE))
+  })
+
+  test_that("works with additional parameters",{
+    skip_on_cran()
+    if(tolower(which)=="pmf"){
+      expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), trans.bins=0:3, label.remaining="rest", calculate.remaining=TRUE, transactions=TRUE, verbose=FALSE))
+
+    }
+    if(tolower(which) == "tracking"){
+      expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), prediction.end=50, cumulative=TRUE, transactions=TRUE,  verbose=FALSE))
+    }
+  })
+}
+
+
 
 fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold){
   test_that("Works for verbose=TRUE",{
@@ -190,13 +224,13 @@ fct.testthat.runability.clvfittedtransactions.plot.pmf <- function(clv.fitted, c
 
 fct.testthat.runability.clvfittedtransactions.plot <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold){
 
-  fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold,
-                                                            which="tracking")
+  fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="tracking")
   fct.testthat.runability.clvfittedtransactions.plot.tracking(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
+  fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="tracking")
 
   if(fct.helper.has.pmf(clv.fitted)){
-    fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold,
-                                                              which="pmf")
+    fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="pmf")
+    fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="pmf")
     fct.testthat.runability.clvfittedtransactions.plot.pmf(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
   }
 }

--- a/tests/testthat/helper_s3_fitted_plot.R
+++ b/tests/testthat/helper_s3_fitted_plot.R
@@ -12,35 +12,61 @@ fct.testthat.runability.clvfittedtransactions.plot.common <- function(clv.fitted
 }
 
 fct.testthat.runability.clvfittedtransactions.plot.other.models <- function(clv.fitted, which, clv.fitted.other){
-
+  skip_on_cran()
+  # same tests but separate for pmf and tracking because use prediction.end=1 to speed up tests which also requires changing expect_silent() to expect_warning()
+  # otherwise takes unacceptably long
+  fct.expect <- function(...){
+    l.args <- list(...)
+    l.default.args <- list(x=clv.fitted, which=which, verbose=FALSE)
+    if(tolower(which) == "tracking"){
+      # speed up
+      l.default.args[["prediction.end"]] <- 1
+      newdata.has.holdout <- FALSE
+      if("newdata" %in% names(l.args)){
+        if(clv.data.has.holdout(l.args[["newdata"]])){
+          newdata.has.holdout <- TRUE
+        }
+      }
+      if(clv.data.has.holdout(clv.fitted@clv.data) | newdata.has.holdout){
+        return(expect_warning(do.call(plot, c(l.args, l.default.args)), regexp = "full holdout"))
+      }else{
+        return(expect_silent(do.call(plot, c(l.args, l.default.args))))
+      }
+    }
+    if(tolower(which)=="pmf"){
+      return(expect_silent(do.call(plot, c(l.args, l.default.args))))
+    }
+  }
+  context("works with and without label")
   test_that("works with and without label",{
     skip_on_cran()
-    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), label=c(), verbose=FALSE))
-    expect_silent(dt.plot <- plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), label=c("this", "again", "other"), verbose=FALSE, plot=FALSE))
+    fct.expect(other.models=list(clv.fitted, clv.fitted.other), label=c())
+    dt.plot <- fct.expect(other.models=list(clv.fitted, clv.fitted.other), label=c("this", "again", "other"), plot=FALSE)
     expect_setequal(dt.plot[, unique(variable)], c("Actual", "this", "again", "other"))
   })
 
-  test_that("works with and without colors",{
+  context("works with and without colors")
+  test_that("works with colors",{
     skip_on_cran()
-    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), verbose=FALSE))
-    expect_silent(plot(clv.fitted, which=which, other.models=list("blue"=clv.fitted, "#00ff00"=clv.fitted.other), verbose=FALSE))
+    fct.expect(other.models=list("blue"=clv.fitted, "#00ff00"=clv.fitted.other))
     # partly named other models
-    expect_silent(plot(clv.fitted, which=which, other.models=list(blue=clv.fitted, clv.fitted.other), verbose=FALSE))
+    fct.expect(other.models=list(blue=clv.fitted, clv.fitted.other))
   })
 
+  context("works with newdata")
   test_that("works with newdata",{
     skip_on_cran()
-    expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), newdata=clv.fitted@clv.data, verbose=FALSE))
+    fct.expect(other.models=list(clv.fitted), newdata=clv.fitted@clv.data)
   })
 
+  context("works with additional parameters")
   test_that("works with additional parameters",{
     skip_on_cran()
     if(tolower(which)=="pmf"){
-      expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), trans.bins=0:3, label.remaining="rest", calculate.remaining=TRUE, transactions=TRUE, verbose=FALSE))
-
+      fct.expect(other.models=list(clv.fitted), trans.bins=0:3, label.remaining="rest", calculate.remaining=TRUE, transactions=TRUE)
     }
     if(tolower(which) == "tracking"){
-      expect_silent(plot(clv.fitted, which=which, other.models=list(clv.fitted, clv.fitted.other), prediction.end=50, cumulative=TRUE, transactions=TRUE,  verbose=FALSE))
+      fct.expect(other.models=list(clv.fitted), cumulative=TRUE, transactions=TRUE)
     }
   })
 }
@@ -48,6 +74,20 @@ fct.testthat.runability.clvfittedtransactions.plot.other.models <- function(clv.
 
 
 fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold){
+  # short prediction.end to speed up tests
+  fct.expect <- function(...){
+    l.args <- list(...)
+    l.default.args <- list(x=clv.fitted, prediction.end=3, verbose=FALSE, plot=FALSE)
+    l.default.args <- modifyList(l.default.args, l.args)
+
+    if(clv.data.has.holdout(clv.fitted@clv.data)){
+      return(expect_warning(do.call(plot, l.default.args), regexp = "full holdout"))
+    }else{
+      return(expect_silent(do.call(plot, l.default.args)))
+    }
+  }
+
+  context("1")
   test_that("Works for verbose=TRUE",{
     skip_on_cran()
     expect_message(plot(clv.fitted, verbose=TRUE))
@@ -59,52 +99,72 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
     })
   }
 
+  context("2")
   test_that("Works for cumulative=TRUE/FALSE",{
     skip_on_cran()
-    expect_silent(plot(clv.fitted, cumulative=TRUE, verbose=FALSE))
-    expect_silent(plot(clv.fitted, cumulative=FALSE, verbose=FALSE))
+    fct.expect(cumulative=TRUE)
+    fct.expect(cumulative=FALSE)
+    # expect_silent(plot(clv.fitted, prediction.end=6, cumulative=TRUE, verbose=FALSE))
+    # expect_silent(plot(clv.fitted, prediction.end=6, cumulative=FALSE, verbose=FALSE))
   })
 
   test_that("Works for plot=FALSE and always has 0 repeat trans and expectation on first",{
     skip_on_cran()
-    expect_silent(dt.plot <- plot(clv.fitted, plot=FALSE, verbose=FALSE))
-    expect_true(isTRUE(all.equal( dt.plot[period.until == min(period.until), value], c(0,0), check.attributes = FALSE)))
+    dt.plot <- fct.expect(plot=FALSE)
+    # expect_silent(dt.plot <- plot(clv.fitted, prediction.end=6, plot=FALSE, verbose=FALSE))
+    expect_true(isTRUE(all.equal(dt.plot[period.until == min(period.until), value], c(0,0))))
   })
 
+  context("3")
   test_that("Works with newdata", {
     skip_on_cran()
-    expect_silent(dt.plot <- plot(clv.fitted, newdata = clv.newdata.nohold, plot=FALSE, verbose=FALSE))
-    # expect_false(anyNA(dt.plot))
+    expect_silent(dt.plot <- plot(clv.fitted, newdata = clv.newdata.nohold, prediction.end=6, plot=FALSE, verbose=FALSE))
+    expect_false(anyNA(dt.plot))
 
-    expect_silent(dt.plot <- plot(clv.fitted, newdata = clv.newdata.withhold, plot=FALSE, verbose=FALSE))
-    # expect_false(anyNA(dt.plot))
+    # dt.plot <- fct.expect(plot=FALSE, newdata = clv.newdata.withhold)
+    expect_warning(dt.plot <- plot(clv.fitted, newdata = clv.newdata.withhold, prediction.end=6, plot=FALSE, verbose=FALSE), regexp = "full holdout")
+    expect_false(anyNA(dt.plot))
 
     # **TODO: Add test to predict that predictions for all Ids in newdata
     # expect_true(dt.plot[])
   })
 
+  context("4")
   test_that("Works for prediction.end in different formats, after holdout", {
     skip_on_cran()
-    # prediction.end as character, Date, posix, numeric
-    expect_silent(plot(clv.fitted, prediction.end = as.character(clv.fitted@clv.data@clv.time@timepoint.holdout.end+lubridate::weeks(26)), verbose=FALSE))
-    expect_silent(plot(clv.fitted, prediction.end = as.Date(clv.fitted@clv.data@clv.time@timepoint.holdout.end+lubridate::weeks(26)), verbose=FALSE))
-    expect_silent(plot(clv.fitted, prediction.end = clv.fitted@clv.data@clv.time@timepoint.holdout.end+lubridate::weeks(26), verbose=FALSE))
-    expect_silent(plot(clv.fitted, prediction.end = as.integer(clv.fitted@clv.data@clv.time@holdout.period.in.tu)+26, verbose=FALSE))
+    if(is(clv.fitted@clv.data@clv.time, "clv.time.date")){
+      tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end+lubridate::days(26)
+    }else{
+      tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end+lubridate::hours(26)
+    }
+    # prediction.end as character, Date, posix, numeric (fct.expect not working here)
+    expect_silent(plot(clv.fitted, prediction.end = as.character(tp.end), verbose=FALSE))
+    expect_silent(plot(clv.fitted, prediction.end = as.Date(tp.end, tz=""), verbose=FALSE))
+    expect_silent(plot(clv.fitted, prediction.end = tp.end, verbose=FALSE))
+    expect_silent(plot(clv.fitted, prediction.end = as.integer(clv.fitted@clv.data@clv.time@holdout.period.in.tu)+4, verbose=FALSE))
   })
 
   if(clv.data.has.holdout(clv.fitted@clv.data)){
     test_that("Warns if ends in holdout", {
       skip_on_cran()
+
+      if(is(clv.fitted@clv.data@clv.time, "clv.time.date")){
+        tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::days(3)
+      }else{
+        tp.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::hours(8)
+      }
+
       # prediction.end as character, Date, posix, numeric
-      expect_warning(plot(clv.fitted, prediction.end = as.character(clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::weeks(6))),
+      expect_warning(plot(clv.fitted, prediction.end = as.character(tp.end)),
                      regexp = "Not plotting full holdout period.")
-      expect_warning(plot(clv.fitted, prediction.end = as.Date(clv.fitted@clv.data@clv.time@timepoint.holdout.end-lubridate::weeks(6))),
+      expect_warning(plot(clv.fitted, prediction.end = as.Date(tp.end)),
                      regexp = "Not plotting full holdout period.")
-      expect_warning(plot(clv.fitted, prediction.end = 6),
+      expect_warning(plot(clv.fitted, prediction.end = 3),
                      regexp = "Not plotting full holdout period.")
     })
   }
 
+  context("5")
   test_that("Works for negative prediction.end", {
     skip_on_cran()
     if(clv.data.has.holdout(clv.fitted@clv.data)){
@@ -117,13 +177,15 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
                      regexp = "Not plotting full estimation period.")
     }
   })
-
+  context("6")
   test_that("Correct return structure", {
     skip_on_cran()
-    expect_silent(gg.plot <- plot(clv.fitted, plot=TRUE, verbose=FALSE))
+    gg.plot <- fct.expect(plot=TRUE)
+    # expect_silent(gg.plot <- plot(clv.fitted, prediction.end=6, plot=TRUE, verbose=FALSE))
     expect_s3_class(gg.plot, "ggplot")
 
-    expect_silent(dt.plot <- plot(clv.fitted, plot=FALSE, verbose=FALSE))
+    dt.plot <- fct.expect(plot=FALSE)
+    # expect_silent(dt.plot <- plot(clv.fitted, prediction.end=6, plot=FALSE, verbose=FALSE))
     expect_s3_class(dt.plot, "data.table")
 
     expect_true(all(c("period.until", "variable", "value") %in% colnames(dt.plot)))
@@ -131,11 +193,11 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
 
     # Num repeat trans may have some NA if prediction.end beyond holdout.end
     expect_false(anyNA(dt.plot[, c("period.until", clv.fitted@clv.model@name.model)]))
-
-    # expect_silent(dt.plot <- plot(clv.fitted, transactions = TRUE, plot=FALSE, verbose=FALSE))
     expect_true(ncol(dt.plot) == 3)
 
-    expect_silent(dt.plot <- plot(clv.fitted, transactions = FALSE, plot=FALSE, verbose=FALSE))
+    # expect_silent(dt.plot <- plot(clv.fitted, transactions = TRUE, plot=FALSE, verbose=FALSE))
+    # expect_silent(dt.plot <- plot(clv.fitted, prediction.end=6, transactions = FALSE, plot=FALSE, verbose=FALSE))
+    dt.plot <- fct.expect(plot=FALSE, transactions = TRUE)
     expect_true(ncol(dt.plot) == 3)
 
     # Same dates/periods for transactions and expectations
@@ -223,16 +285,22 @@ fct.testthat.runability.clvfittedtransactions.plot.pmf <- function(clv.fitted, c
 }
 
 fct.testthat.runability.clvfittedtransactions.plot <- function(clv.fitted, clv.newdata.nohold, clv.newdata.withhold){
-
-  fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="tracking")
+  # context("fct.testthat.runability.clvfittedtransactions.plot.common")
+  # fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="tracking")
+  context("fct.testthat.runability.clvfittedtransactions.plot.tracking")
   fct.testthat.runability.clvfittedtransactions.plot.tracking(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
-  fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="tracking")
-
-  if(fct.helper.has.pmf(clv.fitted)){
-    fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="pmf")
-    fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="pmf")
-    fct.testthat.runability.clvfittedtransactions.plot.pmf(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
-  }
+  # context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
+  # fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="tracking")
+  # context("fct.helper.has.pmf")
+  # test_that("fct.helper.has.pmf", {expect_true(TRUE)})
+  # if(fct.helper.has.pmf(clv.fitted)){
+  #   context("fct.testthat.runability.clvfittedtransactions.plot.common")
+  #   fct.testthat.runability.clvfittedtransactions.plot.common(clv.fitted=clv.fitted, which="pmf")
+  #   context("fct.testthat.runability.clvfittedtransactions.plot.other.models")
+  #   fct.testthat.runability.clvfittedtransactions.plot.other.models(clv.fitted = clv.fitted, clv.fitted.other=clv.fitted, which="pmf")
+  #   context("fct.testthat.runability.clvfittedtransactions.plot.pmf")
+  #   fct.testthat.runability.clvfittedtransactions.plot.pmf(clv.fitted=clv.fitted, clv.newdata.nohold=clv.newdata.nohold, clv.newdata.withhold=clv.newdata.withhold)
+  # }
 }
 
 

--- a/tests/testthat/helper_s3_fitted_plot.R
+++ b/tests/testthat/helper_s3_fitted_plot.R
@@ -34,8 +34,7 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
   test_that("Works for plot=FALSE and always has 0 repeat trans and expectation on first",{
     skip_on_cran()
     expect_silent(dt.plot <- plot(clv.fitted, plot=FALSE, verbose=FALSE))
-    expect_true(isTRUE(all.equal( unlist(dt.plot[period.until == min(period.until), 2:3]),
-                                  c(0,0), check.attributes = FALSE)))
+    expect_true(isTRUE(all.equal( dt.plot[period.until == min(period.until), value], c(0,0), check.attributes = FALSE)))
   })
 
   test_that("Works with newdata", {
@@ -93,9 +92,9 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
     expect_silent(dt.plot <- plot(clv.fitted, plot=FALSE, verbose=FALSE))
     expect_s3_class(dt.plot, "data.table")
 
-    # expect_true(all(c("period.until", "variable", "value") %in% colnames(dt.plot)))
-    expect_true(all(c("period.until", "Actual", clv.fitted@clv.model@name.model)
-                    %in% colnames(dt.plot)))
+    expect_true(all(c("period.until", "variable", "value") %in% colnames(dt.plot)))
+    expect_true(all(c("Actual", clv.fitted@clv.model@name.model) %in% dt.plot[, variable]))
+
     # Num repeat trans may have some NA if prediction.end beyond holdout.end
     expect_false(anyNA(dt.plot[, c("period.until", clv.fitted@clv.model@name.model)]))
 
@@ -103,7 +102,7 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
     expect_true(ncol(dt.plot) == 3)
 
     expect_silent(dt.plot <- plot(clv.fitted, transactions = FALSE, plot=FALSE, verbose=FALSE))
-    expect_true(ncol(dt.plot) == 2)
+    expect_true(ncol(dt.plot) == 3)
 
     # Same dates/periods for transactions and expectations
     #   = also not some expectations missing

--- a/tests/testthat/helper_s3_fitted_plot.R
+++ b/tests/testthat/helper_s3_fitted_plot.R
@@ -37,15 +37,16 @@ fct.testthat.runability.clvfittedtransactions.plot.other.models <- function(clv.
       return(expect_silent(do.call(plot, c(l.args, l.default.args))))
     }
   }
-  context("works with and without label")
-  test_that("works with and without label",{
+  context("works with label")
+  test_that("works withlabel",{
     skip_on_cran()
-    fct.expect(other.models=list(clv.fitted, clv.fitted.other), label=c())
-    dt.plot <- fct.expect(other.models=list(clv.fitted, clv.fitted.other), label=c("this", "again", "other"), plot=FALSE)
-    expect_setequal(dt.plot[, unique(variable)], c("Actual", "this", "again", "other"))
+    # without label is run in most other cases
+    # fct.expect(other.models=list(clv.fitted, clv.fitted.other), label=c())
+    dt.plot <- fct.expect(other.models=list(clv.fitted.other), label=c("this", "other"), plot=FALSE)
+    expect_setequal(dt.plot[, unique(variable)], c("Actual", "this", "other"))
   })
 
-  context("works with and without colors")
+  context("works with colors")
   test_that("works with colors",{
     skip_on_cran()
     fct.expect(other.models=list("blue"=clv.fitted, "#00ff00"=clv.fitted.other))
@@ -100,10 +101,10 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
   }
 
   context("2")
-  test_that("Works for cumulative=TRUE/FALSE",{
+  test_that("Works for cumulative=TRUE",{
     skip_on_cran()
     fct.expect(cumulative=TRUE)
-    fct.expect(cumulative=FALSE)
+    # fct.expect(cumulative=FALSE) # is default anyways
     # expect_silent(plot(clv.fitted, prediction.end=6, cumulative=TRUE, verbose=FALSE))
     # expect_silent(plot(clv.fitted, prediction.end=6, cumulative=FALSE, verbose=FALSE))
   })
@@ -118,15 +119,12 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
   context("3")
   test_that("Works with newdata", {
     skip_on_cran()
-    expect_silent(dt.plot <- plot(clv.fitted, newdata = clv.newdata.nohold, prediction.end=6, plot=FALSE, verbose=FALSE))
+    expect_silent(dt.plot <- plot(clv.fitted, newdata = clv.newdata.nohold, prediction.end=3, plot=FALSE, verbose=FALSE))
     expect_false(anyNA(dt.plot))
 
     # dt.plot <- fct.expect(plot=FALSE, newdata = clv.newdata.withhold)
-    expect_warning(dt.plot <- plot(clv.fitted, newdata = clv.newdata.withhold, prediction.end=6, plot=FALSE, verbose=FALSE), regexp = "full holdout")
+    expect_warning(dt.plot <- plot(clv.fitted, newdata = clv.newdata.withhold, prediction.end=3, plot=FALSE, verbose=FALSE), regexp = "full holdout")
     expect_false(anyNA(dt.plot))
-
-    # **TODO: Add test to predict that predictions for all Ids in newdata
-    # expect_true(dt.plot[])
   })
 
   context("4")
@@ -169,25 +167,25 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
     skip_on_cran()
     if(clv.data.has.holdout(clv.fitted@clv.data)){
       # With holdout: Warn about holdout period
-      expect_warning(plot(clv.fitted, prediction.end=-2,  verbose=FALSE),
+      expect_warning(plot(clv.fitted, prediction.end=-20,  verbose=FALSE),
                      regexp = "Not plotting full holdout period.")
     }else{
       # No holdout: Warn about estimation period
-      expect_warning(plot(clv.fitted, prediction.end=-2,  verbose=FALSE),
+      expect_warning(plot(clv.fitted, prediction.end=-20,  verbose=FALSE),
                      regexp = "Not plotting full estimation period.")
     }
   })
   context("6")
   test_that("Correct return structure", {
     skip_on_cran()
-    gg.plot <- fct.expect(plot=TRUE)
+
     # expect_silent(gg.plot <- plot(clv.fitted, prediction.end=6, plot=TRUE, verbose=FALSE))
+    gg.plot <- fct.expect(plot=TRUE)
     expect_s3_class(gg.plot, "ggplot")
 
     dt.plot <- fct.expect(plot=FALSE)
     # expect_silent(dt.plot <- plot(clv.fitted, prediction.end=6, plot=FALSE, verbose=FALSE))
     expect_s3_class(dt.plot, "data.table")
-
     expect_true(all(c("period.until", "variable", "value") %in% colnames(dt.plot)))
     expect_true(all(c("Actual", clv.fitted@clv.model@name.model) %in% dt.plot[, variable]))
 
@@ -196,9 +194,9 @@ fct.testthat.runability.clvfittedtransactions.plot.tracking <- function(clv.fitt
     expect_true(ncol(dt.plot) == 3)
 
     # expect_silent(dt.plot <- plot(clv.fitted, transactions = TRUE, plot=FALSE, verbose=FALSE))
-    # expect_silent(dt.plot <- plot(clv.fitted, prediction.end=6, transactions = FALSE, plot=FALSE, verbose=FALSE))
-    dt.plot <- fct.expect(plot=FALSE, transactions = TRUE)
-    expect_true(ncol(dt.plot) == 3)
+    # expect_silent(dt.plot <- plot(clv.fitted, transactions = FALSE, plot=FALSE, verbose=FALSE))
+    # dt.plot <- fct.expect(plot=FALSE, transactions = TRUE)
+    # expect_true(ncol(dt.plot) == 3)
 
     # Same dates/periods for transactions and expectations
     #   = also not some expectations missing

--- a/tests/testthat/helper_s3_fitted_predict.R
+++ b/tests/testthat/helper_s3_fitted_predict.R
@@ -161,7 +161,7 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
     skip_on_cran()
 
     fct.predict <- function(end.1, end.2, end.3, ...){
-      if(is(fitted.transactions@clv.data@clv.time, "clv.time.date") & (is.POSIXct(end.1) | is.POSIXlt(end.1))){
+      if(is(fitted.transactions@clv.data@clv.time, "clv.time.date") & (is.POSIXct(end.1) | lubridate::is.POSIXlt(end.1))){
         expect_message(dt.pred.1 <- predict(fitted.transactions,prediction.end = end.1, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")
         expect_message(dt.pred.2 <- predict(fitted.transactions,prediction.end = end.2, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")
         expect_message(dt.pred.3 <- predict(fitted.transactions,prediction.end = end.3, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")

--- a/tests/testthat/helper_s3_fitted_predict.R
+++ b/tests/testthat/helper_s3_fitted_predict.R
@@ -1,6 +1,5 @@
 fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transactions, clv.newdata.nohold, clv.newdata.withhold){
 
-
   # Only for models which were fit with heldout data
   if(clv.data.has.holdout(fitted.transactions@clv.data)){
     test_that("Works without parameters (has holdout)", {
@@ -8,7 +7,8 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
     })
     test_that("Works with prediction end in holdout period", {
       skip_on_cran()
-      expect_silent(dt.pred <- predict(fitted.transactions,prediction.end = as.character(fitted.transactions@clv.data@clv.time@timepoint.holdout.end - lubridate::days(30)), verbose=FALSE))
+      expect_silent(dt.pred <- predict(fitted.transactions,prediction.end = as.character(fitted.transactions@clv.data@clv.time@timepoint.holdout.end - lubridate::days(1)),
+                                       predict.spending=FALSE, verbose=FALSE))
       # then also has actuals
       expect_true(c("actual.x" %in% colnames(dt.pred)))
 
@@ -26,8 +26,8 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
   #   actual.total.spending all > 0
   #   actual.transactions all > 0
   # predicted CLV is = X*Y
-
   if(clv.data.has.spending(fitted.transactions@clv.data)){
+
     test_that("Predict works with logical for predict.spending", {
       skip_on_cran()
       skip_on_ci()
@@ -57,7 +57,9 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
       # mix it all up: predict for clv.newdata.withhold using spending model fitted on clv.newdata.nohold
       #   but use newdata with different Ids to see a difference to the one used for spending model fitting
       subset.id  <- fitted.transactions@clv.data@data.transactions[, sample(x = unique(Id), size = uniqueN(Id)/2)]
-      clv.subset <- clvdata(fitted.transactions@clv.data@data.transactions[Id %in% subset.id], "ymd", "w")
+      clv.subset <- clvdata(fitted.transactions@clv.data@data.transactions[Id %in% subset.id],
+                            date.format=fitted.transactions@clv.data@clv.time@time.format,
+                            time.unit=fitted.transactions@clv.data@clv.time@name.time.unit)
       if(is(fitted.transactions@clv.data, "clv.data.static.covariates")){
         clv.subset <- SetStaticCovariates(clv.subset,
                                           data.cov.life  = fitted.transactions@clv.data@data.cov.life[Id %in% subset.id],  names.cov.life = fitted.transactions@clv.data@names.cov.data.life,
@@ -89,7 +91,7 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
 
   test_that("Formal correct", {
     skip_on_cran()
-    expect_silent(dt.pred <- predict(fitted.transactions, prediction.end = 6, verbose = FALSE))
+    expect_silent(dt.pred <- predict(fitted.transactions, prediction.end = 6, predict.spending=FALSE, verbose = FALSE))
     expect_true(dt.pred[, data.table::uniqueN(Id)] == fitted.transactions@clv.data@data.transactions[, data.table::uniqueN(Id)])
     # all ids in predictions
     expect_true(nrow(data.table::fsetdiff(fitted.transactions@clv.data@data.transactions[, "Id"], dt.pred[, "Id"]))==0)
@@ -126,9 +128,9 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
   if(fct.helper.has.DERT(fitted.transactions)){
     test_that("Works with discount factor", {
       skip_on_cran()
-      expect_silent(dt.pred.1 <- predict(fitted.transactions, continuous.discount.factor = 0.001,prediction.end = 6, verbose=FALSE))
-      expect_silent(dt.pred.2 <- predict(fitted.transactions, continuous.discount.factor = 0.06, prediction.end = 6, verbose=FALSE))
-      expect_silent(dt.pred.3 <- predict(fitted.transactions, continuous.discount.factor = 0.99, prediction.end = 6, verbose=FALSE))
+      expect_silent(dt.pred.1 <- predict(fitted.transactions, continuous.discount.factor = 0.001,prediction.end = 6, predict.spending=FALSE, verbose=FALSE))
+      expect_silent(dt.pred.2 <- predict(fitted.transactions, continuous.discount.factor = 0.06, prediction.end = 6, predict.spending=FALSE, verbose=FALSE))
+      expect_silent(dt.pred.3 <- predict(fitted.transactions, continuous.discount.factor = 0.99, prediction.end = 6, predict.spending=FALSE, verbose=FALSE))
       expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
       expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
       expect_true(dt.pred.1[, all(is.finite(DERT))])
@@ -136,23 +138,6 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
       expect_true(dt.pred.3[, all(is.finite(DERT))])
     })
   }
-
-  test_that("Works with different types of prediction.end: number, date, posix, char (short) ",{
-    # not checking anything correctness on cran, just run
-    expect_silent(predict(fitted.transactions,prediction.end = 4, verbose=FALSE))
-    pred.end.char <- as.character(as.Date(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(30), tz=""))
-
-    expect_silent(predict(fitted.transactions,prediction.end = pred.end.char, verbose=FALSE))
-    expect_silent(predict(fitted.transactions,prediction.end = as.Date(lubridate::ymd(pred.end.char)), verbose=FALSE))
-    if(lubridate::is.POSIXct(fitted.transactions@clv.data@clv.time@timepoint.estimation.start)){
-      expect_silent(predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char)), verbose=FALSE))
-      expect_silent(predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char)), verbose=FALSE))
-    }else{
-      expect_message(predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char)), verbose=FALSE), regexp = "ignored")
-      expect_message(predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char)), verbose=FALSE), regexp = "ignored")
-    }
-  })
-
 
   test_that("Works with different newdata", {
     skip_on_cran()
@@ -172,57 +157,66 @@ fct.testthat.runability.clvfittedtransactions.predict <- function(fitted.transac
     expect_true(all(unique(clv.newdata.nohold@data.transactions$Id) %in% dt.pred$Id))
   })
 
-  # **TODO: Fix date converting
   test_that("Works with different types of prediction.end: number, date, posix, char (long)", {
     skip_on_cran()
 
-    expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = 4, verbose=FALSE))
-    expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = 26, verbose=FALSE))
-    expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = 104, verbose=FALSE))
-    expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-    expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-
-    pred.end.char.1 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(30))
-    pred.end.char.2 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(180))
-    pred.end.char.3 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::years(1))
-
-    expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = pred.end.char.1, verbose=FALSE))
-    expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = pred.end.char.2, verbose=FALSE))
-    expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = pred.end.char.3, verbose=FALSE))
-    expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-    expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-
-    expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = lubridate::ymd(pred.end.char.1), verbose=FALSE))
-    expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = lubridate::ymd(pred.end.char.2), verbose=FALSE))
-    expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = lubridate::ymd(pred.end.char.3), verbose=FALSE))
-    expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-    expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-
-    if(lubridate::is.POSIXct(fitted.transactions@clv.data@clv.time@timepoint.estimation.start)){
-      expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.1)), verbose=FALSE))
-      expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.2)), verbose=FALSE))
-      expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.3)), verbose=FALSE))
-      expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-      expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-
-      expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.1)), verbose=FALSE))
-      expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.2)), verbose=FALSE))
-      expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.3)), verbose=FALSE))
-      expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-      expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-    }else{
-      expect_message(dt.pred.1 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.1)), verbose=FALSE), regexp = "ignored")
-      expect_message(dt.pred.2 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.2)), verbose=FALSE), regexp = "ignored")
-      expect_message(dt.pred.3 <- predict(fitted.transactions,prediction.end = as.POSIXct(lubridate::ymd(pred.end.char.3)), verbose=FALSE), regexp = "ignored")
-      expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
-      expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
-
-      expect_message(dt.pred.1 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.1)), verbose=FALSE), regexp = "ignored")
-      expect_message(dt.pred.2 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.2)), verbose=FALSE), regexp = "ignored")
-      expect_message(dt.pred.3 <- predict(fitted.transactions,prediction.end = as.POSIXlt(lubridate::ymd(pred.end.char.3)), verbose=FALSE), regexp = "ignored")
+    fct.predict <- function(end.1, end.2, end.3, ...){
+      if(is(fitted.transactions@clv.data@clv.time, "clv.time.date") & (is.POSIXct(end.1) | is.POSIXlt(end.1))){
+        expect_message(dt.pred.1 <- predict(fitted.transactions,prediction.end = end.1, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")
+        expect_message(dt.pred.2 <- predict(fitted.transactions,prediction.end = end.2, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")
+        expect_message(dt.pred.3 <- predict(fitted.transactions,prediction.end = end.3, predict.spending=FALSE, verbose=FALSE), regexp = "cut off")
+      }else{
+        expect_silent(dt.pred.1 <- predict(fitted.transactions,prediction.end = end.1, predict.spending=FALSE, verbose=FALSE))
+        expect_silent(dt.pred.2 <- predict(fitted.transactions,prediction.end = end.2, predict.spending=FALSE, verbose=FALSE))
+        expect_silent(dt.pred.3 <- predict(fitted.transactions,prediction.end = end.3, predict.spending=FALSE, verbose=FALSE))
+      }
       expect_false(isTRUE(all.equal(dt.pred.1, dt.pred.2)))
       expect_false(isTRUE(all.equal(dt.pred.2, dt.pred.3)))
     }
+
+
+    if(lubridate::is.POSIXct(fitted.transactions@clv.data@clv.time@timepoint.estimation.start)){
+      # long enough to not such that as.Date() falls below estimation.split
+      pred.end.char.1 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::hours(24))
+      pred.end.char.2 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::hours(100))
+      pred.end.char.3 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::hours(200))
+
+      # sure different from each other and after estimation.end
+      pred.end.date.1 <- as.Date(lubridate::ymd_hms(pred.end.char.1))
+      pred.end.date.2 <- as.Date(lubridate::ymd_hms(pred.end.char.2))
+      pred.end.date.3 <- as.Date(lubridate::ymd_hms(pred.end.char.3))
+
+      pred.end.posixct.1 <- as.POSIXct(lubridate::ymd_hms(pred.end.char.1), tz="UTC")
+      pred.end.posixct.2 <- as.POSIXct(lubridate::ymd_hms(pred.end.char.2), tz="UTC")
+      pred.end.posixct.3 <- as.POSIXct(lubridate::ymd_hms(pred.end.char.3), tz="UTC")
+
+      pred.end.posixlt.1 <- as.POSIXlt(lubridate::ymd_hms(pred.end.char.1), tz="UTC")
+      pred.end.posixlt.2 <- as.POSIXlt(lubridate::ymd_hms(pred.end.char.2), tz="UTC")
+      pred.end.posixlt.3 <- as.POSIXlt(lubridate::ymd_hms(pred.end.char.3), tz="UTC")
+
+    }else{
+      pred.end.char.1 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(3))
+      pred.end.char.2 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(180))
+      pred.end.char.3 <- as.character(fitted.transactions@clv.data@clv.time@timepoint.estimation.end+lubridate::days(365))
+
+      pred.end.date.1 <- lubridate::ymd(pred.end.char.1)
+      pred.end.date.2 <- lubridate::ymd(pred.end.char.2)
+      pred.end.date.3 <- lubridate::ymd(pred.end.char.3)
+
+      pred.end.posixct.1 <- as.POSIXct(lubridate::ymd(pred.end.char.1))
+      pred.end.posixct.2 <- as.POSIXct(lubridate::ymd(pred.end.char.2))
+      pred.end.posixct.3 <- as.POSIXct(lubridate::ymd(pred.end.char.3))
+
+      pred.end.posixlt.1 <- as.POSIXlt(lubridate::ymd(pred.end.char.1))
+      pred.end.posixlt.2 <- as.POSIXlt(lubridate::ymd(pred.end.char.2))
+      pred.end.posixlt.3 <- as.POSIXlt(lubridate::ymd(pred.end.char.3))
+    }
+
+    fct.predict(4, 26, 52)
+    fct.predict(pred.end.char.1, pred.end.char.2, pred.end.char.3)
+    fct.predict(pred.end.date.1, pred.end.date.2, pred.end.date.3)
+    fct.predict(pred.end.posixct.1, pred.end.posixct.2, pred.end.posixct.3)
+    fct.predict(pred.end.posixlt.1, pred.end.posixlt.2, pred.end.posixlt.3)
   })
 
 }

--- a/tests/testthat/helper_testthat_consistency.R
+++ b/tests/testthat/helper_testthat_consistency.R
@@ -109,11 +109,7 @@ fct.testthat.consistency.cov.params.0.plot.same <- function(fitted.nocov, fitted
     expect_warning(dt.plot.nocov     <- plot(fitted.nocov,  verbose=FALSE, plot=FALSE, prediction.end = 10), regexp = "full holdout")
     expect_warning(dt.plot.cov       <- plot(fitted.cov.g0, verbose=FALSE, plot=FALSE, prediction.end = 10), regexp = "full holdout")
 
-    # Rename to random names because have different colnames by model
-    data.table::setnames(dt.plot.nocov,  c("A", "B", "C"))
-    data.table::setnames(dt.plot.cov ,   c("A", "B", "C"))
-
-    expect_true(isTRUE(all.equal(dt.plot.nocov, dt.plot.cov)))
+    expect_true(isTRUE(all.equal(dt.plot.nocov[, c("period.until", "value")], dt.plot.cov[, c("period.until", "value")])))
   })
 }
 
@@ -126,8 +122,8 @@ fct.testthat.consistency.cov.params.0.pmf.same <- function(fitted.nocov, fitted.
 
 fct.testthat.consistency.cov.params.0.pmf.plot.same <- function(fitted.nocov, fitted.cov.g0){
   test_that("pmf plot same results for all models with gamma=0", {
-    expect_true(isTRUE(all.equal(plot(fitted.nocov,  which="pmf", verbose=FALSE, plot=FALSE),
-                                 plot(fitted.cov.g0, which="pmf", verbose=FALSE, plot=FALSE))))
+    expect_true(isTRUE(all.equal(plot(fitted.nocov,  which="pmf", verbose=FALSE, plot=FALSE)[, c("num.transactions", "value")],
+                                 plot(fitted.cov.g0, which="pmf", verbose=FALSE, plot=FALSE)[, c("num.transactions", "value")])))
   })
 }
 

--- a/tests/testthat/helper_testthat_correctness_clvfitted.R
+++ b/tests/testthat/helper_testthat_correctness_clvfitted.R
@@ -11,7 +11,7 @@ fct.testthat.correctness.clvfitted.flawless.results.out.of.the.box <- function(m
 
     expect_false(fct.DT.any.non.finite(predict(fitted, verbose = FALSE)))
     if(is(fitted, "clv.fitted.transactions")){
-      expect_false(fct.DT.any.non.finite(plot(fitted, plot = FALSE, verbose = FALSE)[, !"Actual"]))
+      expect_false(fct.DT.any.non.finite(plot(fitted, plot = FALSE, verbose = FALSE)))
     }
     # KKTs both true
     expect_true(res.sum$kkt1)

--- a/tests/testthat/helper_testthat_inputchecks_nocov.R
+++ b/tests/testthat/helper_testthat_inputchecks_nocov.R
@@ -88,7 +88,7 @@ fct.testthat.inputchecks.startparamcor <- function(method, l.std.args, correct.p
   test_that("Fails if more than 1", {
     expect_error(do.call(method, modifyList(l.std.args,
                                             list(start.param.cor = rep(correct.param,2)))),
-                 regexp = "single")
+                 regexp = "exactly 1 single number")
   })
 
   test_that("Fails if is NA", {

--- a/tests/testthat/helper_testthat_runability_dynamiccov.R
+++ b/tests/testthat/helper_testthat_runability_dynamiccov.R
@@ -19,8 +19,7 @@ fct.testthat.runability.dynamiccov.plot.has.0.repeat.transactions.expectations <
   test_that("Plot always has 0 on repeat transactions and expectations", {
     expect_warning(dt.plot <- plot(clv.fitted, prediction.end = 5, verbose=FALSE, plot=FALSE),
                    regexp = "Not plotting full holdout period")
-    expect_true(isTRUE(all.equal(unlist(dt.plot[period.until == min(period.until), c(2,3)]),
-                                 c(0,0), check.attributes = FALSE)))
+    expect_true(isTRUE(all.equal(dt.plot[period.until == min(period.until), value], c(0,0))))
   })
 }
 

--- a/tests/testthat/helper_testthat_runability_nocov.R
+++ b/tests/testthat/helper_testthat_runability_nocov.R
@@ -95,8 +95,8 @@ fct.testthat.runability.nocov <- function(name.model, method, cdnow,
   fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data= clv.data.cdnow.noholdout,
                                                                   l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
 
-  # **TODO: fix ggomnbd?
-  # fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = cdnow)
+  fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = cdnow, start.params.model=start.params.model,
+                                                fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3, l.args.test.all.s3=l.args.test.all.s3)
 
 
   # Nocov tests ------------------------------------------------------------------------------------------------------------

--- a/tests/testthat/helper_testthat_runability_nocov.R
+++ b/tests/testthat/helper_testthat_runability_nocov.R
@@ -93,7 +93,6 @@ fct.testthat.runability.nocov <- function(name.model, method, cdnow,
   fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data= clv.data.cdnow.noholdout,
                                                                   l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
 
-  # context("hourly data")
   # fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = cdnow, start.params.model=start.params.model,
   #                                               fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3, l.args.test.all.s3=l.args.test.all.s3)
 

--- a/tests/testthat/helper_testthat_runability_nocov.R
+++ b/tests/testthat/helper_testthat_runability_nocov.R
@@ -73,9 +73,11 @@ fct.testthat.runability.nocov <- function(name.model, method, cdnow,
   clv.newdata.nohold   <- fct.helper.create.fake.newdata.nocov(data = cdnow, estimation.split = NULL)
   clv.newdata.withhold <- fct.helper.create.fake.newdata.nocov(data = cdnow, estimation.split = 37)
 
+  # S3 are tested in .testthat. functions using l.args.test.all.s3 args
   param.names <- names(start.params.model)
   l.args.test.all.s3 <- list(full.names = param.names, clv.newdata.nohold = clv.newdata.nohold,
                              clv.newdata.withhold = clv.newdata.withhold)
+
 
   # Common tests ------------------------------------------------------------------------------------------------------------
   fct.testthat.runability.clvfitted.out.of.the.box.no.hold(method = method, clv.data.noholdout = clv.data.cdnow.noholdout,

--- a/tests/testthat/helper_testthat_runability_nocov.R
+++ b/tests/testthat/helper_testthat_runability_nocov.R
@@ -93,8 +93,9 @@ fct.testthat.runability.nocov <- function(name.model, method, cdnow,
   fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data= clv.data.cdnow.noholdout,
                                                                   l.args.test.all.s3 = l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3)
 
-  fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = cdnow, start.params.model=start.params.model,
-                                                fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3, l.args.test.all.s3=l.args.test.all.s3)
+  # context("hourly data")
+  # fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = cdnow, start.params.model=start.params.model,
+  #                                               fct.test.all.s3=fct.helper.clvfittedtransactions.all.s3, l.args.test.all.s3=l.args.test.all.s3)
 
 
   # Nocov tests ------------------------------------------------------------------------------------------------------------

--- a/tests/testthat/helper_testthat_runability_spending.R
+++ b/tests/testthat/helper_testthat_runability_spending.R
@@ -33,8 +33,8 @@ fct.testthat.runability.clvfittedspending <- function(name.model, method,
   fct.testthat.runability.clvfitted.multiple.optimization.methods(method = method, clv.data = clv.data.cdnow.withholdout,
                                                                   l.args.test.all.s3= l.args.test.all.s3, fct.test.all.s3=fct.helper.clvfittedspending.all.s3)
 
-  fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = data.cdnow,
-                                                fct.test.all.s3 = fct.helper.clvfittedspending.all.s3, l.args.test.all.s3 = l.args.test.all.s3)
+  # fct.testthat.runability.clvfitted.hourly.data(method = method, data.cdnow = data.cdnow,
+  #                                               fct.test.all.s3 = fct.helper.clvfittedspending.all.s3, l.args.test.all.s3 = l.args.test.all.s3)
 
 
   # Also works with covariate data ------------------------------------------------------------------------------------

--- a/tests/testthat/test_inputchecks_clvdata_clvdata.R
+++ b/tests/testthat/test_inputchecks_clvdata_clvdata.R
@@ -90,7 +90,7 @@ test_that("Fails if not character", {
   expect_error(clvdata(date.format = lubridate::ymd, data.transactions = cdnow, time.unit = "w"), regexp = "character")
   expect_error(clvdata(date.format = Sys.Date(), data.transactions = cdnow, time.unit = "w"), regexp = "character")
 
-  expect_error(clvdata(date.format = character(0), data.transactions = cdnow, time.unit = "w"), regexp = "single")
+  expect_error(clvdata(date.format = character(0), data.transactions = cdnow, time.unit = "w"), regexp = "exactly 1 element")
   expect_error(clvdata(date.format = list("ymd"), data.transactions = cdnow, time.unit = "w"), regexp = "character")
   expect_error(clvdata(date.format = data.frame("ymd"), data.transactions = cdnow, time.unit = "w"), regexp = "character")
 })
@@ -105,8 +105,8 @@ test_that("Fails if date.format wrong format", {
 })
 
 test_that("Fails if has multiple", {
-  expect_error(clvdata(date.format = c("ymd", "ymd"), data.transactions = cdnow, time.unit = "w"), regexp = "single")
-  expect_error(clvdata(date.format = c("ymd", "dmy"), data.transactions = cdnow, time.unit = "w"), regexp = "single")
+  expect_error(clvdata(date.format = c("ymd", "ymd"), data.transactions = cdnow, time.unit = "w"), regexp = "exactly 1 element")
+  expect_error(clvdata(date.format = c("ymd", "dmy"), data.transactions = cdnow, time.unit = "w"), regexp = "exactly 1 element")
 })
 
 
@@ -141,7 +141,7 @@ test_that("Fails if not character", {
 
 test_that("Fails if wrong time.unit format", {
   expect_error(clvdata(time.unit = character(0), data.transactions = cdnow, date.format="ymd"),
-               regexp = "one single element")
+               regexp = "exactly 1 element")
   expect_error(clvdata(time.unit = "beeks", data.transactions = cdnow, date.format="ymd"),
                regexp = "one of the following")
   expect_error(clvdata(time.unit = "decade", data.transactions = cdnow, date.format="ymd"),
@@ -154,9 +154,9 @@ test_that("Fails if wrong time.unit format", {
 
 test_that("Fails if has multiple", {
   expect_error(clvdata(time.unit = c("weeks", "years"), data.transactions = cdnow, date.format="ymd"),
-               regexp = "one single element")
+               regexp = "exactly 1 element")
   expect_error(clvdata(time.unit = c("weeks", "weeks"), data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Has no default argument", {
@@ -182,11 +182,11 @@ test_that("Fails if not numeric, character, or date",{
                regexp = "can be converted")
 
   expect_error(clvdata(estimation.split = character(0),time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "one single element")
+               regexp = "exactly one single element")
   expect_error(clvdata(estimation.split = numeric(),time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "one single element")
+               regexp = "exactly one single element")
   expect_error(clvdata(estimation.split = as.Date(character(0)),time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "one single element")
+               regexp = "exactly one single element")
   expect_error(clvdata(estimation.split = as.Date(NA_character_),time.unit = "w", data.transactions = cdnow, date.format="ymd"),
                regexp = "any NA")
 })
@@ -241,7 +241,7 @@ test_that("Fails if NA/NULL", {
   expect_error(clvdata(name.id = NA_character_, time.unit = "w", data.transactions = cdnow, date.format="ymd"),
                regexp = "any NA")
   expect_error(clvdata(name.id = character(0), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -255,9 +255,9 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(clvdata(name.id = c("Id", "Id"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(clvdata(name.id = c("Id", "Date"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {
@@ -288,7 +288,7 @@ test_that("Fails if NA/NULL", {
   expect_error(clvdata(name.date = NA_character_, time.unit = "w", data.transactions = cdnow, date.format="ymd"),
                regexp = "any NA")
   expect_error(clvdata(name.date = character(0), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -302,9 +302,9 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(clvdata(name.date = c("Id", "Id"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(clvdata(name.date = c("Id", "Date"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {
@@ -338,7 +338,7 @@ test_that("Fails if NA/empty", {
   expect_error(clvdata(name.price = NA_character_, time.unit = "w", data.transactions = cdnow, date.format="ymd"),
                regexp = "any NA")
   expect_error(clvdata(name.price = character(0), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -352,9 +352,9 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(clvdata(name.price = c("Id", "Id"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(clvdata(name.price = c("Id", "Date"), time.unit = "w", data.transactions = cdnow, date.format="ymd"),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {

--- a/tests/testthat/test_inputchecks_clvdata_plot.R
+++ b/tests/testthat/test_inputchecks_clvdata_plot.R
@@ -42,8 +42,8 @@ test_that("tracking - Stops for unneeded parameters", {
 test_that("frequency - label.remaining is single character", {
   expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=NA_character_), regexp = "may not contain")
   expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=NULL), regexp = "of type character")
-  expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=character(0)), regexp = "single element")
-  expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=c("10+", ">10")), regexp = "single element")
+  expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=character(0)), regexp = "exactly 1 element")
+  expect_error(plot(clv.cdnow.nohold, which="frequency", label.remaining=c("10+", ">10")), regexp = "exactly 1 element")
 })
 
 test_that("frequency - trans.bins is valid", {

--- a/tests/testthat/test_inputchecks_clvdata_setdynamiccov.R
+++ b/tests/testthat/test_inputchecks_clvdata_setdynamiccov.R
@@ -577,7 +577,7 @@ test_that("Fails if NA/NULL", {
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.id=NA_character_))),
                regexp = "any NA")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.id=character(0)))),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -591,11 +591,11 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.id=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.id=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.id=c("Id", "Date")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {
@@ -626,7 +626,7 @@ test_that("Fails if NA/NULL", {
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.date=NA_character_))),
                regexp = "any NA")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.date=character(0)))),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -640,11 +640,11 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.date=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.date=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetDynamicCovariates, modifyList(l.std.args, list(name.date=c("Id", "Date")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {

--- a/tests/testthat/test_inputchecks_clvdata_setstaticcov.R
+++ b/tests/testthat/test_inputchecks_clvdata_setstaticcov.R
@@ -326,7 +326,7 @@ test_that("Fails if NA/NULL", {
   expect_error(do.call(SetStaticCovariates, modifyList(l.std.args, list(name.id=NA_character_))),
                regexp = "any NA")
   expect_error(do.call(SetStaticCovariates, modifyList(l.std.args, list(name.id=character(0)))),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not character", {
@@ -340,11 +340,11 @@ test_that("Fails if not character", {
 
 test_that("Fails if multiple", {
   expect_error(do.call(SetStaticCovariates, modifyList(l.std.args, list(name.id=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetStaticCovariates, modifyList(l.std.args, list(name.id=c("Id", "Id")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
   expect_error(do.call(SetStaticCovariates, modifyList(l.std.args, list(name.id=c("Id", "Date")), keep.null = TRUE)),
-               regexp = "single element")
+               regexp = "exactly 1 element")
 })
 
 test_that("Fails if not in transaction data", {

--- a/tests/testthat/test_inputchecks_plot_transactions.R
+++ b/tests/testthat/test_inputchecks_plot_transactions.R
@@ -27,6 +27,47 @@ fct.testthat.inputchecks.clvfittedtransactions.plot.ellipsis <- function(l.std.a
   })
 }
 
+fct.testthat.inputchecks.clvfittedtransactions.othermodels.are.not.fitted.transaction.models <- function(clv.fitted, which){
+  test_that("other.models is not list", {
+    expect_error(plot(clv.fitted, which=which, other.models=NULL), regexp = "list of fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=123), regexp = "list of fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=clv.fitted), regexp = "list of fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=clv.fitted@clv.data), regexp = "list of fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=bgnbd), regexp = "list of fitted transaction models")
+  })
+
+  test_that("other.models contains element which are not clv.fitted.transactions", {
+    expect_error(plot(clv.fitted, which=which, other.models=list(1, 2, 3)), regexp = "fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted, NA)), regexp = "fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted, 2, clv.fitted)), regexp = "fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted@clv.data)), regexp = "fitted transaction models")
+    expect_error(plot(clv.fitted, which=which, other.models=list(pnbd, bgnbd)), regexp = "fitted transaction models")
+  })
+}
+
+
+fct.testthat.inputchecks.clvfittedtransactions.plot.label.with.othermodels <- function(clv.fitted, which, clv.fitted.other){
+
+  test_that("label has required length", {
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other), label="other"), regexp = "contain exactly")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other, clv.fitted.other), label=c("this", "other")), regexp = "contain exactly")
+  })
+
+
+  test_that("label has no empty text elements", {
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other), label=c("this", "")), regexp = "empty")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other), label=c("", "other")), regexp = "empty")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other), label=c("", "")), regexp = "empty")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other, clv.fitted.other), label=c("this", "other", "")), regexp = "empty")
+  })
+
+  test_that("label has no duplicates", {
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other), label=c("other", "other")), regexp = "duplicate")
+    expect_error(plot(clv.fitted, which=which, other.models=list(clv.fitted.other, clv.fitted.other), label=c("this", "other", "other")), regexp = "duplicate")
+  })
+
+}
+
 fct.testthat.inputchecks.clvfittedtransactions.plot.pmf.trans.bins <- function(clv.fitted){
   test_that("trans.bins is valid input (integer vector)", {
     skip_on_cran()
@@ -117,12 +158,19 @@ fct.testthat.inputchecks.clvfittedtransactions.plot.common <- function(which, l.
                                                                             clv.data.no.cov = clv.data.cdnow.nohold,
                                                                             clv.data.static.cov = clv.data.apparel.static.cov)
 
+  context(paste0("Inputchecks - clv.fitted.transactions plot ",which," - other.models"))
+  fct.testthat.inputchecks.clvfittedtransactions.othermodels.are.not.fitted.transaction.models(clv.fitted = fitted.cdnow.nohold, which = which)
+  fct.testthat.inputchecks.clvfittedtransactions.othermodels.are.not.fitted.transaction.models(clv.fitted = fitted.apparel.static, which = which)
+
+  # Label for single model and for when other.models is specified
+  context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - label, no other.models"))
+  fct.helper.inputcheck.single.character(fct = plot, l.std.args = l.std.args, name.param = "label", null.allowed = TRUE)
+
+  context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - label, with other.models"))
+  fct.testthat.inputchecks.clvfittedtransactions.plot.label.with.othermodels(clv.fitted=fitted.cdnow.nohold, which=which, clv.fitted.other=fitted.apparel.static)
 
   context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - transactions"))
   .fct.helper.inputchecks.single.logical(fct = plot, l.std.args = l.std.args, name.param = "transactions")
-
-  context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - label"))
-  fct.helper.inputcheck.single.character(fct = plot, l.std.args = l.std.args, name.param = "label", null.allowed = TRUE)
 
   context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - plot"))
   .fct.helper.inputchecks.single.logical(fct = plot, l.std.args = l.std.args, name.param = "plot")

--- a/tests/testthat/test_inputchecks_plot_transactions.R
+++ b/tests/testthat/test_inputchecks_plot_transactions.R
@@ -151,15 +151,12 @@ fct.testthat.inputchecks.clvfittedtransactions.plot.common <- function(which, l.
                                                                             clv.data.no.cov = clv.data.cdnow.nohold,
                                                                             clv.data.static.cov = clv.data.apparel.static.cov)
 
-  context(paste0("Inputchecks - clv.fitted.transactions plot ",which," - other.models"))
   fct.testthat.inputchecks.clvfittedtransactions.othermodels.are.not.fitted.transaction.models(clv.fitted = fitted.cdnow.nohold, which = which)
   fct.testthat.inputchecks.clvfittedtransactions.othermodels.are.not.fitted.transaction.models(clv.fitted = fitted.apparel.static, which = which)
 
   # Label for single model and for when other.models is specified
-  context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - label, no other.models"))
   fct.helper.inputcheck.single.character(fct = plot, l.std.args = l.std.args, name.param = "label", null.allowed = TRUE)
 
-  context(paste0("Inputchecks - clv.fitted.transactions plot ", which," - label, with other.models"))
   fct.testthat.inputchecks.clvfittedtransactions.plot.label.with.othermodels(clv.fitted=fitted.cdnow.nohold, which=which, clv.fitted.other=fitted.apparel.static)
 
   .fct.helper.inputchecks.single.logical(fct = plot, l.std.args = l.std.args, name.param = "transactions")

--- a/tests/testthat/test_inputchecks_predict_transactions.R
+++ b/tests/testthat/test_inputchecks_predict_transactions.R
@@ -61,7 +61,7 @@ fct.testthat.inputchecks.clvfittedtransactions.predict.predict.spending.wrong.ty
 
     # illegal logical
     expect_error(predict(clv.fitted.transactions, prediction.end = 6, predict.spending = NA), regexp = "cannot be NA")
-    expect_error(predict(clv.fitted.transactions, prediction.end = 6, predict.spending = c(TRUE, TRUE)), regexp = "single")
+    expect_error(predict(clv.fitted.transactions, prediction.end = 6, predict.spending = c(TRUE, TRUE)), regexp = "only contain 1 element")
 
     # other than logical
     expect_error(predict(clv.fitted.transactions, prediction.end = 6, predict.spending = NULL), regexp = "has to be either")

--- a/tests/testthat/test_runability_clvdata_s3.R
+++ b/tests/testthat/test_runability_clvdata_s3.R
@@ -68,7 +68,7 @@ fct.helper.test.runability.clv.data.trackingplot <- function(clv.data){
     skip_on_cran()
     expect_message(dt.plot <- plot(clv.data, plot=FALSE), regexp = "Plotting")
     expect_s3_class(dt.plot, "data.table")
-    expect_true(isTRUE(all.equal(unlist(dt.plot[period.until == min(period.until), value]), 0, check.attributes = FALSE)))
+    expect_true(isTRUE(all.equal(dt.plot[period.until == min(period.until), value], 0)))
   })
 
   test_that("plot, verbose = TRUE", {

--- a/tests/testthat/test_runability_clvdata_s3.R
+++ b/tests/testthat/test_runability_clvdata_s3.R
@@ -68,8 +68,7 @@ fct.helper.test.runability.clv.data.trackingplot <- function(clv.data){
     skip_on_cran()
     expect_message(dt.plot <- plot(clv.data, plot=FALSE), regexp = "Plotting")
     expect_s3_class(dt.plot, "data.table")
-    expect_true(isTRUE(all.equal(unlist(dt.plot[period.until == min(period.until), 2]),
-                                 0, check.attributes = FALSE)))
+    expect_true(isTRUE(all.equal(unlist(dt.plot[period.until == min(period.until), value]), 0, check.attributes = FALSE)))
   })
 
   test_that("plot, verbose = TRUE", {


### PR DESCRIPTION
Draw other fitted models next to the main one, by specifying them in a new argument `other.models`.

- The idea is to first collect plot data from all models and concatenate it to a single data.table. This table is then used for plotting. The data of the main model is collected with actuals (if desired), other models are always without actuals. Requires plotting output to be in long format for all plots in order to concatenate them. 
- For all models, the data is collected by calling the generic plot(plot=F) with the same arguments as the original call to plot(). This also takes care of all the input checks and replacing clv.data with newdata if it is given.
- No checks that all models were fit on the same clv.data object are done. 
- If no newdata is given, each models own clv.data object is used
- The names of other.models are used as plotting colors for each model
- Label models in the plot using the existing argument `label` which now takes more than a single element. If not given uses built-in model names, made unique.