### PR TITLE
Remove cxxstd flag from makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -8,8 +8,11 @@
 ## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
 ## support within Armadillo prefers / requires it
 ##
-## also needed for gamma function in Armadillo
-CXX_STD = CXX11
+## R 4.0.0 made C++11 the default, R 4.1.0 switched to C++14, R 4.3.0 to C++17
+## _In general_ we should no longer need to set a standard as any recent R
+## installation will do the right thing. Should you need it, uncomment it and
+## set the appropriate value, possibly CXX17.
+#CXX_STD = CXX11
 
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `$(R_HOME)/bin/Rscript -e "RcppGSL:::LdFlags()"`

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -8,8 +8,11 @@
 ## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
 ## support within Armadillo prefers / requires it
 ##
-## also needed for gamma function in Armadillo
-CXX_STD = CXX11
+## R 4.0.0 made C++11 the default, R 4.1.0 switched to C++14, R 4.3.0 to C++17
+## _In general_ we should no longer need to set a standard as any recent R
+## installation will do the right thing. Should you need it, uncomment it and
+## set the appropriate value, possibly CXX17.
+#CXX_STD = CXX11
 
 #PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 #PKG_LIBS = $(SHLIB_OPENMP_CFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
No longer needed nowadays and has also been updated in the RcppArmadillo skeleton
