### PR TITLE
gg cbs creation: use existing repeat transactions

### DIFF
--- a/R/class_clv_data.R
+++ b/R/class_clv_data.R
@@ -82,6 +82,11 @@ clv.data.get.transactions.in.estimation.period <- function(clv.data){
   return(clv.data@data.transactions[Date <= clv.data@clv.time@timepoint.estimation.end])
 }
 
+clv.data.get.repeat.transactions.in.estimation.period <- function(clv.data){
+  Date <- NULL
+  return(clv.data@data.repeat.trans[Date <= clv.data@clv.time@timepoint.estimation.end])
+}
+
 clv.data.get.transactions.in.holdout.period <- function(clv.data){
   Date <- NULL
   stopifnot(clv.data.has.holdout(clv.data))

--- a/R/class_clv_gg.R
+++ b/R/class_clv_gg.R
@@ -59,8 +59,7 @@ gg_cbs <- function(clv.data, remove.first.transaction){
 
     # Add statistics based on repeat transactions only
     #   Cannot use clv.data@data.repeat.trans because these also include holdout
-    dt.transactions        <- clv.data.get.transactions.in.estimation.period(clv.data)
-    dt.repeat.transactions <- clv.data.make.repeat.transactions(dt.transactions)
+    dt.repeat.transactions <- clv.data.get.repeat.transactions.in.estimation.period(clv.data)
 
     dt.stats.repeat.trans <- dt.repeat.transactions[ , list(x         = .N,
                                                             Spending  = mean(Price)),

--- a/tests/testthat/test_correctness_clvdata_clvdata.R
+++ b/tests/testthat/test_correctness_clvdata_clvdata.R
@@ -391,3 +391,15 @@ test_that("Aggregating first and removing after removes all first transactions",
 })
 
 
+test_that("clv.data.get.repeat.transactions.in.estimation.period() is the same as creating repeat transactions from estimation period data", {
+  skip_on_cran()
+
+  clv.cdnow <- clvdata(cdnow, date.format = "ymd", time.unit = "w", estimation.split = NULL)
+
+  dt.estimation.period   <- clv.data.get.transactions.in.estimation.period(clv.cdnow)
+  dt.self.made.repeat    <- clv.data.make.repeat.transactions(dt.estimation.period)
+
+  expect_true(fsetequal(clv.data.get.repeat.transactions.in.estimation.period(clv.cdnow),
+                        dt.self.made.repeat))
+})
+


### PR DESCRIPTION
- dont create repeat transactions again because resource intensive
- use existing code as test