### PR TITLE
Predictions: Add column `predicted.total.spending`

### DIFF
--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -273,6 +273,9 @@ setMethod("clv.controlflow.predict.post.process.prediction.table", signature = s
       dt.predictions[, predicted.CLV := DERT * predicted.mean.spending]
     if("DECT" %in% colnames(dt.predictions))
       dt.predictions[, predicted.CLV := DECT * predicted.mean.spending]
+
+    # If spending is predicted, also add predicted.total.spending
+    dt.predictions[, predicted.total.spending := predicted.mean.spending * CET]
   }
 
   # Present cols in desired order ------------------------------------------------------------
@@ -292,7 +295,7 @@ setMethod("clv.controlflow.predict.post.process.prediction.table", signature = s
     cols <- c(cols, "PAlive", "CET", "DECT")
 
   if(do.predict.spending)
-    cols <- c(cols, "predicted.mean.spending")
+    cols <- c(cols, c("predicted.mean.spending", "predicted.total.spending"))
 
   if("predicted.CLV" %in% colnames(dt.predictions))
     cols <- c(cols, "predicted.CLV")

--- a/R/f_interface_predict_clvfittedtransactions.R
+++ b/R/f_interface_predict_clvfittedtransactions.R
@@ -63,11 +63,12 @@
 #' \item{period.last}{Last timepoint of prediction period}
 #' \item{period.length}{Number of time units covered by the period indicated by \code{period.first} and \code{period.last} (including both ends).}
 #' \item{PAlive}{Probability to be alive at the end of the estimation period}
-#' \item{CET}{The Conditional Expected Transactions}
+#' \item{CET}{The Conditional Expected Transactions: The number of transactions expected until prediction.end.}
 #' \item{DERT or DECT}{Discounted Expected Residual Transactions or Discounted Expected Conditional Transactions for dynamic covariates models}
-#' \item{actual.x}{Actual number of transactions until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise it is not reported.}
-#' \item{actual.total.spending}{Actual total spending until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise it is not reported.}
+#' \item{actual.x}{Actual number of transactions until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise not reported.}
+#' \item{actual.total.spending}{Actual total spending until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise not reported.}
 #' \item{predicted.mean.spending}{The mean spending per transactions as predicted by the spending model.}
+#' \item{predicted.total.spending}{The predicted total spending until prediction.end (\code{CET*predicted.mean.spending}).}
 #' \item{predicted.CLV}{Customer Lifetime Value based on \code{DERT/DECT} and \code{predicted.mean.spending}.}
 #'
 #' @examples

--- a/man/predict.clv.fitted.transactions.Rd
+++ b/man/predict.clv.fitted.transactions.Rd
@@ -48,11 +48,12 @@ An object of class \code{data.table} with columns:
 \item{period.last}{Last timepoint of prediction period}
 \item{period.length}{Number of time units covered by the period indicated by \code{period.first} and \code{period.last} (including both ends).}
 \item{PAlive}{Probability to be alive at the end of the estimation period}
-\item{CET}{The Conditional Expected Transactions}
+\item{CET}{The Conditional Expected Transactions: The number of transactions expected until prediction.end.}
 \item{DERT or DECT}{Discounted Expected Residual Transactions or Discounted Expected Conditional Transactions for dynamic covariates models}
-\item{actual.x}{Actual number of transactions until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise it is not reported.}
-\item{actual.total.spending}{Actual total spending until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise it is not reported.}
+\item{actual.x}{Actual number of transactions until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise not reported.}
+\item{actual.total.spending}{Actual total spending until prediction.end. Only if there is a holdout period and the prediction ends in it, otherwise not reported.}
 \item{predicted.mean.spending}{The mean spending per transactions as predicted by the spending model.}
+\item{predicted.total.spending}{The predicted total spending until prediction.end (\code{CET*predicted.mean.spending}).}
 \item{predicted.CLV}{Customer Lifetime Value based on \code{DERT/DECT} and \code{predicted.mean.spending}.}
 }
 \description{


### PR DESCRIPTION
Add column with the total spending expected for the prediction period (CET*predicted.mean.spending) to facilitate comparison with existing `actual.total.spending`