### PR TITLE
clvdata S3 methods: Harmonize `id`/`Id` arguments to `ids`

### DIFF
--- a/R/class_clv_data.R
+++ b/R/class_clv_data.R
@@ -171,27 +171,27 @@ clv.data.mean.interpurchase.times <- function(clv.data, dt.transactions){
 
 #' @importFrom stats sd
 #' @importFrom lubridate time_length
-clv.data.make.descriptives <- function(clv.data, Ids){
+clv.data.make.descriptives <- function(clv.data, ids){
 
   Id <- Date <- .N <- N <- Price <- interp.time<- Name <- Holdout <- NULL
 
   # readability
   clv.time <- clv.data@clv.time
 
-  Ids <- unique(Ids)
+  ids <- unique(ids)
 
   # Make descriptives ------------------------------------------------------------------------------
   #   Do not simply overwrite all NA/NaN with "-", only where these are expected (num obs = 1).
   #     Let propagate otherwise to help find errors
   fct.make.descriptives <- function(dt.data, sample.name){
 
-    # Subset transaction data to relevant Ids
-    if(!is.null(Ids)){
-      dt.data <- dt.data[Id %in% Ids]
+    # Subset transaction data to relevant ids
+    if(!is.null(ids)){
+      dt.data <- dt.data[Id %in% ids]
 
       # print warning only once
-      if(sample.name == "Total" & dt.data[, uniqueN(Id)] != length(unique(Ids))){
-        warning("Not all given Ids were found in the transaction data.", call. = FALSE)
+      if(sample.name == "Total" & dt.data[, uniqueN(Id)] != length(unique(ids))){
+        warning("Not all given ids were found in the transaction data.", call. = FALSE)
       }
 
     }
@@ -247,9 +247,9 @@ clv.data.make.descriptives <- function(clv.data, Ids){
   dt.summary[, Holdout := "-"]
   if(clv.data.has.holdout(clv.data)){
     dt.trans.holdout <- clv.data.get.transactions.in.holdout.period(clv.data = clv.data)
-    # Need to subset to Ids here already to check if there actually are transactions in holdout period
-    if(!is.null(Ids)){
-      dt.trans.holdout <- dt.trans.holdout[Id %in% Ids]
+    # Need to subset to ids here already to check if there actually are transactions in holdout period
+    if(!is.null(ids)){
+      dt.trans.holdout <- dt.trans.holdout[Id %in% ids]
     }
     if(nrow(dt.trans.holdout) > 0){
       dt.summary[, Holdout := fct.make.descriptives(dt.data = dt.trans.holdout, sample.name="Holdout")]

--- a/R/f_clvdata_inputchecks.R
+++ b/R/f_clvdata_inputchecks.R
@@ -98,41 +98,41 @@ check_userinput_datanocov_transbins <- function(trans.bins, count.repeat.trans){
   return(c())
 }
 
-check_userinput_datanocov_ids <- function(Ids){
+check_userinput_datanocov_ids <- function(ids){
   err.msg <- c()
 
-  if(is.null(Ids)){
+  if(is.null(ids)){
     return(err.msg)
   }
 
-  if(anyNA(Ids)){
-    return("Ids may not contain any NA!")
+  if(anyNA(ids)){
+    return("Parameter 'ids' may not contain any NA!")
   }
 
-  if(!is.numeric(Ids) & !is.character(Ids)){
-    return("Ids has to be a single numeric value or a character vector!")
+  if(!is.numeric(ids) & !is.character(ids)){
+    return("Parameter 'ids' has to be a single numeric value or a character vector!")
   }
 
 
-  if(is.numeric(Ids)){
-    err.msg <- c(err.msg, .check_user_data_single_numeric(Ids, var.name = 'Ids'))
-    # if(any(!is.finite(Ids))){
-    #   return("Ids may not contain any non-finite elements if numeric!")
+  if(is.numeric(ids)){
+    err.msg <- c(err.msg, .check_user_data_single_numeric(ids, var.name = 'ids'))
+    # if(any(!is.finite(ids))){
+    #   return("ids may not contain any non-finite elements if numeric!")
     # }
-    # if(length(Ids) != 1){
-    #   return("Ids has to be of length 1 if numeric!")
+    # if(length(ids) != 1){
+    #   return("ids has to be of length 1 if numeric!")
     # }
-    if(!all(Ids > 0)){
-      err.msg <- c(err.msg, "Ids has to be strictly positive (>0)")
+    if(!all(ids > 0)){
+      err.msg <- c(err.msg, "Parameter 'ids' has to be strictly positive (>0)")
     }
   }
 
-  if(is.character(Ids)){
-    if(length(Ids) == 0){
-      err.msg <- c(err.msg, "Ids has to contain at least 1 element if character vector")
+  if(is.character(ids)){
+    if(length(ids) == 0){
+      err.msg <- c(err.msg, "Parameter 'ids' has to contain at least 1 element if character vector")
     }else{
-      if(any(nchar(Ids) == 0)){
-        err.msg <- c(err.msg, "Ids may not be empty text")
+      if(any(nchar(ids) == 0)){
+        err.msg <- c(err.msg, "Parameter 'ids' may not be empty text")
       }
     }
 

--- a/R/f_s3generics_clvdata.R
+++ b/R/f_s3generics_clvdata.R
@@ -142,7 +142,7 @@ summary.clv.data <- function(object, ids=NULL, ...){
   res$clv.time         <- object@clv.time # needed for formatting when printing
   res$summary.clv.time <- summary(object@clv.time)
 
-  res$descriptives.transactions <- clv.data.make.descriptives(clv.data=object, Ids = ids)
+  res$descriptives.transactions <- clv.data.make.descriptives(clv.data=object, ids = ids)
   res$selected.ids <- unique(ids)
 
   return(res)

--- a/R/f_s3generics_clvdata.R
+++ b/R/f_s3generics_clvdata.R
@@ -135,15 +135,15 @@ print.clv.data.dynamic.covariates <- function(x, digits = max(3L, getOption("dig
 #' @template template_summary_data
 #' @template template_param_dots
 #' @export
-summary.clv.data <- function(object, Id=NULL, ...){
+summary.clv.data <- function(object, ids=NULL, ...){
   res <- structure(list(), class="summary.clv.data")
 
   res$name             <- object@name
   res$clv.time         <- object@clv.time # needed for formatting when printing
   res$summary.clv.time <- summary(object@clv.time)
 
-  res$descriptives.transactions <- clv.data.make.descriptives(clv.data=object, Ids = Id)
-  res$selected.ids <- unique(Id)
+  res$descriptives.transactions <- clv.data.make.descriptives(clv.data=object, Ids = ids)
+  res$selected.ids <- unique(ids)
 
   return(res)
 }

--- a/R/f_s3generics_clvdata.R
+++ b/R/f_s3generics_clvdata.R
@@ -8,7 +8,7 @@
 #' @export
 as.data.table.clv.data <- function(x,
                                    keep.rownames = FALSE,
-                                   Ids = NULL,
+                                   ids = NULL,
                                    sample = c("full", "estimation", "holdout"),
                                    ...){
   Id <- NULL
@@ -18,14 +18,14 @@ as.data.table.clv.data <- function(x,
   dt.trans <- clv.data.select.sample.data(clv.data=x, sample=sample,
                                           choices = c("full", "estimation", "holdout"))
 
-  if(is.null(Ids)){
+  if(is.null(ids)){
     return(dt.trans)
   }else{
-    dt.trans <- dt.trans[Id %in% Ids]
+    dt.trans <- dt.trans[Id %in% ids]
 
-    # ***TODO: Should stop instead of warn if not all Ids are there?
-    if(dt.trans[, uniqueN(Id)] != length(unique(Ids))){
-      warning("Not for all of the given Ids transaction data could be found")
+    # ***TODO: Should stop instead of warn if not all ids are there?
+    if(dt.trans[, uniqueN(Id)] != length(unique(ids))){
+      warning("Not for all of the given ids transaction data could be found")
     }
     return(dt.trans)
   }
@@ -42,10 +42,10 @@ as.data.table.clv.data <- function(x,
 as.data.frame.clv.data <- function(x,
                                    row.names = NULL,
                                    optional = NULL,
-                                   Ids = NULL,
+                                   ids = NULL,
                                    sample = c("full", "estimation", "holdout"),
                                    ...){
-  return(as.data.frame(as.data.table.clv.data(x, Ids=Ids, sample=sample, ...=...)))
+  return(as.data.frame(as.data.table.clv.data(x, ids=ids, sample=sample, ...=...)))
 }
 
 

--- a/R/f_s3generics_clvdata_plot.R
+++ b/R/f_s3generics_clvdata_plot.R
@@ -20,7 +20,7 @@
 #' @param mean.spending "spending": Whether customer's mean spending per transaction (\code{TRUE}, default) or the
 #' value of every transaction in the data (\code{FALSE}) should be plotted.
 #'
-#' @param Ids "timings": A character vector of customer ids or a single integer specifying the number of customers to sample.
+#' @param ids "timings": A character vector of customer ids or a single integer specifying the number of customers to sample.
 #' Defaults to \code{NULL} for which 50 random customers are selected.
 #' @param annotate.ids "timings": Whether timelines should be annotated with customer ids.
 #'
@@ -155,13 +155,13 @@
 #'
 #' ### TIMING PATTERNS
 #' # selected customers and annotating them
-#' plot(clv.cdnow, which="timings", Ids=c("123", "1041"), annotate.ids=TRUE)
+#' plot(clv.cdnow, which="timings", ids=c("123", "1041"), annotate.ids=TRUE)
 #'
 #' # plot 25 random customers
-#' plot(clv.cdnow, which="timings", Ids=25)
+#' plot(clv.cdnow, which="timings", ids=25)
 #'
 #' # plot all customers
-#' plot(clv.cdnow, which="timings", Ids=nobs(clv.cdnow))
+#' plot(clv.cdnow, which="timings", ids=nobs(clv.cdnow))
 #' }
 #'
 #' @importFrom graphics plot
@@ -178,7 +178,7 @@ plot.clv.data <- function(x, which=c("tracking", "frequency", "spending", "inter
                           mean.spending=TRUE,
                           # timings
                           annotate.ids=FALSE,
-                          Ids=c(),
+                          ids=c(),
                           # all density
                           sample=c("estimation", "full", "holdout"),
                           geom="line", color="black",
@@ -216,7 +216,7 @@ plot.clv.data <- function(x, which=c("tracking", "frequency", "spending", "inter
                                           plot=plot, verbose=verbose,
                                           color=color, ...),
          "timings" =
-           clv.data.plot.transaction.timings(clv.data = x, Ids = Ids,
+           clv.data.plot.transaction.timings(clv.data = x, ids = ids,
                                              annotate.ids = annotate.ids,
                                              plot = plot, verbose = verbose,
                                              ...)
@@ -488,13 +488,13 @@ clv.data.plot.barplot.frequency <- function(clv.data, count.repeat.trans, count.
 
 
 #' @importFrom ggplot2 ggplot geom_segment geom_point geom_text geom_vline theme xlab ylab ylim ggtitle element_blank scale_x_datetime scale_x_date
-clv.data.plot.transaction.timings <- function(clv.data, Ids, annotate.ids, plot, verbose, ...){
+clv.data.plot.transaction.timings <- function(clv.data, ids, annotate.ids, plot, verbose, ...){
   # cran silence
   Id <- x <- y <- i.y <- date.first.actual.trans <- xstart <- xend <- ystart <- yend <- type <- Date <- NULL
 
   err.msg <- c()
   err.msg <- c(err.msg, .check_user_data_single_boolean(b=annotate.ids, var.name="annotate.ids"))
-  err.msg <- c(err.msg, check_userinput_datanocov_ids(Ids=Ids))
+  err.msg <- c(err.msg, check_userinput_datanocov_ids(ids=ids))
   err.msg <- c(err.msg, check_user_data_emptyellipsis(...))
   check_err_msg(err.msg)
 
@@ -511,22 +511,22 @@ clv.data.plot.transaction.timings <- function(clv.data, Ids, annotate.ids, plot,
   # Select first transaction of all ids, sample if ids not given
   dt.customer.y <- pnbd_cbs(clv.data)
 
-  Ids <- unique(Ids)
-  if(is.null(Ids) | (length(Ids) == 1 & is.numeric(Ids))){
+  ids <- unique(ids)
+  if(is.null(ids) | (length(ids) == 1 & is.numeric(ids))){
     # sample given number of random customers (50 if none given)
-    if(is.null(Ids)){
-      Ids <- 50
+    if(is.null(ids)){
+      ids <- 50
     }
-    if(Ids > nobs(clv.data)){
-      Ids <- nobs(clv.data)
+    if(ids > nobs(clv.data)){
+      ids <- nobs(clv.data)
       warning(paste0("Id may not be larger than the number of customers and is set to ", nobs(clv.data), "."))
     }
-    Ids <- dt.customer.y[, sample(x = Id, size = Ids, replace = FALSE)]
+    ids <- dt.customer.y[, sample(x = Id, size = ids, replace = FALSE)]
   }
-  if(!all(Ids %in% dt.customer.y[, unique(Id)])){
-    warning("Not all given Ids were found in the transaction data.", call. = FALSE)
+  if(!all(ids %in% dt.customer.y[, unique(Id)])){
+    warning("Not all given ids were found in the transaction data.", call. = FALSE)
   }
-  dt.customer.y <- dt.customer.y[Id %in% Ids, c("Id", "date.first.actual.trans")]
+  dt.customer.y <- dt.customer.y[Id %in% ids, c("Id", "date.first.actual.trans")]
 
   # Determine y position based on date of first transaction
   #   shortest on top, ordered by Id if same timepoint
@@ -542,14 +542,14 @@ clv.data.plot.transaction.timings <- function(clv.data, Ids, annotate.ids, plot,
   # x: transaction
   # y: per customer y
   dt.calibration <- clv.data.get.transactions.in.estimation.period(clv.data)
-  dt.calibration <- dt.calibration[Id %in% Ids]
+  dt.calibration <- dt.calibration[Id %in% ids]
   dt.calibration[, x := Date]
   dt.calibration[dt.customer.y, y := i.y, on="Id"]
 
   # Points in holdout period
   if(clv.data.has.holdout(clv.data)){
     dt.holdout <- clv.data.get.transactions.in.holdout.period(clv.data)
-    dt.holdout <- dt.holdout[Id %in% Ids]
+    dt.holdout <- dt.holdout[Id %in% ids]
     dt.holdout[, x := Date]
     dt.holdout[dt.customer.y, y := i.y, on="Id"]
   }

--- a/man-roxygen/template_clvdata_asdatax.R
+++ b/man-roxygen/template_clvdata_asdatax.R
@@ -4,7 +4,7 @@
 #' into a <%=name_data_code%>.
 #'
 #' @param x An object of class \code{clv.data}.
-#' @param Ids Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.
+#' @param ids Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.
 #' @param sample Name of sample for which transactions should be extracted,
 #' either "estimation", "holdout", or "full" (default).
 #'
@@ -19,18 +19,18 @@
 #'                           time.unit = "w",
 #'                           estimation.split = 37)
 #'
-#' # Extract all transaction data (all Ids, estimation and holdout period)
+#' # Extract all transaction data (all ids, estimation and holdout period)
 #' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow)
 #'
 #' # Extract transaction data of estimation period
 #' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow, sample="estimation")
 #'
-#' # Extract transaction data of Ids "1", "2", and "999"
+#' # Extract transaction data of ids "1", "2", and "999"
 #' #  (estimation and holdout period)
-#' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow, Ids = c("1", "2", "999"))
+#' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow, ids = c("1", "2", "999"))
 #'
-#' # Extract transaction data of Ids "1", "2", and "999" in estimation period
-#' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow, Ids = c("1", "2", "999"),
+#' # Extract transaction data of ids "1", "2", and "999" in estimation period
+#' <%=name_res%> <- as.<%=name_data_code%>(clv.data.cdnow, ids = c("1", "2", "999"),
 #'                           sample="estimation")
 #'}
 #'

--- a/man-roxygen/template_summary_data.R
+++ b/man-roxygen/template_summary_data.R
@@ -1,7 +1,7 @@
 #' @title Summarizing a CLV data object
 #'
 #' @param object A CLV data object containing transactional data and potentially also contextual factors.
-#' @param Id A character vector of customer ids for which the transaction data is summarized. Defaults to
+#' @param ids A character vector of customer ids for which the transaction data is summarized. Defaults to
 #' \code{NULL} for all customers.
 #'
 #' @description
@@ -12,7 +12,7 @@
 #'
 #' @details
 #' If applicable, the summary statistics are provided separately for the estimation and holdout period as well as
-#' for the overall time period (estimation + holdout). By using the \code{Id} argument, the summary statistics can
+#' for the overall time period (estimation + holdout). By using the \code{ids} argument, the summary statistics can
 #' be limited to a subset of customers.
 #' \describe{
 #' \item{\code{Number of customers}}{Count of individual customers.}
@@ -63,10 +63,10 @@
 #' summary(clv.data.apparel)
 #'
 #' # transaction summary of customer "1219"
-#' summary(clv.data.apparel, Id="1219")
+#' summary(clv.data.apparel, ids="1219")
 #'
 #' # transaction summary of customers "1", "10", "100", and "1000"
-#' summary(clv.data.apparel, Id=c("1", "10", "100", "1000"))
+#' summary(clv.data.apparel, ids=c("1", "10", "100", "1000"))
 #'
 #' # add contextual factors
 #' data("apparelStaticCov")

--- a/man/as.data.frame.clv.data.Rd
+++ b/man/as.data.frame.clv.data.Rd
@@ -8,7 +8,7 @@
   x,
   row.names = NULL,
   optional = NULL,
-  Ids = NULL,
+  ids = NULL,
   sample = c("full", "estimation", "holdout"),
   ...
 )
@@ -20,7 +20,7 @@
 
 \item{optional}{Ignored}
 
-\item{Ids}{Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.}
+\item{ids}{Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.}
 
 \item{sample}{Name of sample for which transactions should be extracted,
 either "estimation", "holdout", or "full" (default).}
@@ -42,18 +42,18 @@ clv.data.cdnow <- clvdata(data.transactions = cdnow,
                           time.unit = "w",
                           estimation.split = 37)
 
-# Extract all transaction data (all Ids, estimation and holdout period)
+# Extract all transaction data (all ids, estimation and holdout period)
 df.trans <- as.data.frame(clv.data.cdnow)
 
 # Extract transaction data of estimation period
 df.trans <- as.data.frame(clv.data.cdnow, sample="estimation")
 
-# Extract transaction data of Ids "1", "2", and "999"
+# Extract transaction data of ids "1", "2", and "999"
 #  (estimation and holdout period)
-df.trans <- as.data.frame(clv.data.cdnow, Ids = c("1", "2", "999"))
+df.trans <- as.data.frame(clv.data.cdnow, ids = c("1", "2", "999"))
 
-# Extract transaction data of Ids "1", "2", and "999" in estimation period
-df.trans <- as.data.frame(clv.data.cdnow, Ids = c("1", "2", "999"),
+# Extract transaction data of ids "1", "2", and "999" in estimation period
+df.trans <- as.data.frame(clv.data.cdnow, ids = c("1", "2", "999"),
                           sample="estimation")
 }
 

--- a/man/as.data.table.clv.data.Rd
+++ b/man/as.data.table.clv.data.Rd
@@ -7,7 +7,7 @@
 \method{as.data.table}{clv.data}(
   x,
   keep.rownames = FALSE,
-  Ids = NULL,
+  ids = NULL,
   sample = c("full", "estimation", "holdout"),
   ...
 )
@@ -17,7 +17,7 @@
 
 \item{keep.rownames}{Ignored}
 
-\item{Ids}{Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.}
+\item{ids}{Character vector of customer ids for which transactions should be extracted. \code{NULL} extracts all.}
 
 \item{sample}{Name of sample for which transactions should be extracted,
 either "estimation", "holdout", or "full" (default).}
@@ -40,18 +40,18 @@ clv.data.cdnow <- clvdata(data.transactions = cdnow,
                           time.unit = "w",
                           estimation.split = 37)
 
-# Extract all transaction data (all Ids, estimation and holdout period)
+# Extract all transaction data (all ids, estimation and holdout period)
 dt.trans <- as.data.table(clv.data.cdnow)
 
 # Extract transaction data of estimation period
 dt.trans <- as.data.table(clv.data.cdnow, sample="estimation")
 
-# Extract transaction data of Ids "1", "2", and "999"
+# Extract transaction data of ids "1", "2", and "999"
 #  (estimation and holdout period)
-dt.trans <- as.data.table(clv.data.cdnow, Ids = c("1", "2", "999"))
+dt.trans <- as.data.table(clv.data.cdnow, ids = c("1", "2", "999"))
 
-# Extract transaction data of Ids "1", "2", and "999" in estimation period
-dt.trans <- as.data.table(clv.data.cdnow, Ids = c("1", "2", "999"),
+# Extract transaction data of ids "1", "2", and "999" in estimation period
+dt.trans <- as.data.table(clv.data.cdnow, ids = c("1", "2", "999"),
                           sample="estimation")
 }
 

--- a/man/plot.clv.data.Rd
+++ b/man/plot.clv.data.Rd
@@ -15,7 +15,7 @@
   label.remaining = "10+",
   mean.spending = TRUE,
   annotate.ids = FALSE,
-  Ids = c(),
+  ids = c(),
   sample = c("estimation", "full", "holdout"),
   geom = "line",
   color = "black",
@@ -47,7 +47,7 @@ value of every transaction in the data (\code{FALSE}) should be plotted.}
 
 \item{annotate.ids}{"timings": Whether timelines should be annotated with customer ids.}
 
-\item{Ids}{"timings": A character vector of customer ids or a single integer specifying the number of customers to sample.
+\item{ids}{"timings": A character vector of customer ids or a single integer specifying the number of customers to sample.
 Defaults to \code{NULL} for which 50 random customers are selected.}
 
 \item{sample}{Name of the sample for which the plot should be made, either
@@ -192,13 +192,13 @@ plot(clv.cdnow, which="interpurchasetime",
 
 ### TIMING PATTERNS
 # selected customers and annotating them
-plot(clv.cdnow, which="timings", Ids=c("123", "1041"), annotate.ids=TRUE)
+plot(clv.cdnow, which="timings", ids=c("123", "1041"), annotate.ids=TRUE)
 
 # plot 25 random customers
-plot(clv.cdnow, which="timings", Ids=25)
+plot(clv.cdnow, which="timings", ids=25)
 
 # plot all customers
-plot(clv.cdnow, which="timings", Ids=nobs(clv.cdnow))
+plot(clv.cdnow, which="timings", ids=nobs(clv.cdnow))
 }
 
 }

--- a/man/summary.clv.data.Rd
+++ b/man/summary.clv.data.Rd
@@ -10,7 +10,7 @@
 \alias{print.summary.clv.data.static.covariates}
 \title{Summarizing a CLV data object}
 \usage{
-\method{summary}{clv.data}(object, Id = NULL, ...)
+\method{summary}{clv.data}(object, ids = NULL, ...)
 
 \method{print}{summary.clv.data}(x, digits = max(3L, getOption("digits") - 3L), ...)
 
@@ -25,7 +25,7 @@
 \arguments{
 \item{object}{A CLV data object containing transactional data and potentially also contextual factors.}
 
-\item{Id}{A character vector of customer ids for which the transaction data is summarized. Defaults to
+\item{ids}{A character vector of customer ids for which the transaction data is summarized. Defaults to
 \code{NULL} for all customers.}
 
 \item{...}{Ignored}
@@ -56,7 +56,7 @@ possible holdout sample, and descriptive statistics of the transaction data.
 }
 \details{
 If applicable, the summary statistics are provided separately for the estimation and holdout period as well as
-for the overall time period (estimation + holdout). By using the \code{Id} argument, the summary statistics can
+for the overall time period (estimation + holdout). By using the \code{ids} argument, the summary statistics can
 be limited to a subset of customers.
 \describe{
 \item{\code{Number of customers}}{Count of individual customers.}
@@ -87,10 +87,10 @@ clv.data.apparel <- clvdata(apparelTrans, date.format = "ymd",
 summary(clv.data.apparel)
 
 # transaction summary of customer "1219"
-summary(clv.data.apparel, Id="1219")
+summary(clv.data.apparel, ids="1219")
 
 # transaction summary of customers "1", "10", "100", and "1000"
-summary(clv.data.apparel, Id=c("1", "10", "100", "1000"))
+summary(clv.data.apparel, ids=c("1", "10", "100", "1000"))
 
 # add contextual factors
 data("apparelStaticCov")

--- a/tests/testthat/test_correctness_clvdata_s3.R
+++ b/tests/testthat/test_correctness_clvdata_s3.R
@@ -34,8 +34,8 @@ test_that("Summary has no NA", {
   clv.cdnow.holdout <- fct.helper.create.clvdata.cdnow(cdnow, estimation.split = 37)
   clv.cdnow.no.holdout <- fct.helper.create.clvdata.cdnow(cdnow, estimation.split = NULL)
 
-  fct.summary.has.no.na <- function(clv.data, Id){
-    expect_silent(res.sum <- summary(clv.data, Id=Id))
+  fct.summary.has.no.na <- function(clv.data, ids){
+    expect_silent(res.sum <- summary(clv.data, ids=ids))
     # Returns characters and cannot convert to numeric because would
     #   surely introduce NAs (converting dates and "-")
     expect_false(any(res.sum$descriptives.transactions == "NA"))
@@ -43,17 +43,17 @@ test_that("Summary has no NA", {
   }
 
   # All
-  fct.summary.has.no.na(clv.cdnow.holdout, Id=NULL)
-  fct.summary.has.no.na(clv.cdnow.no.holdout, Id=NULL)
+  fct.summary.has.no.na(clv.cdnow.holdout, ids=NULL)
+  fct.summary.has.no.na(clv.cdnow.no.holdout, ids=NULL)
   # Zero-repeater
-  fct.summary.has.no.na(clv.cdnow.holdout, Id="3")
-  fct.summary.has.no.na(clv.cdnow.no.holdout, Id="3")
+  fct.summary.has.no.na(clv.cdnow.holdout, ids="3")
+  fct.summary.has.no.na(clv.cdnow.no.holdout, ids="3")
   # Not zero-repeater
-  fct.summary.has.no.na(clv.cdnow.holdout, Id="1")
-  fct.summary.has.no.na(clv.cdnow.no.holdout, Id="1")
+  fct.summary.has.no.na(clv.cdnow.holdout, ids="1")
+  fct.summary.has.no.na(clv.cdnow.no.holdout, ids="1")
   # Mix
-  fct.summary.has.no.na(clv.cdnow.holdout, Id=c("1", "3"))
-  fct.summary.has.no.na(clv.cdnow.no.holdout, Id=c("1", "3"))
+  fct.summary.has.no.na(clv.cdnow.holdout, ids=c("1", "3"))
+  fct.summary.has.no.na(clv.cdnow.no.holdout, ids=c("1", "3"))
 
 })
 
@@ -61,8 +61,8 @@ test_that("Same transaction summary if all ids or NULL are given", {
   skip_on_cran()
   clv.cdnow <- fct.helper.create.clvdata.cdnow(cdnow)
 
-  expect_silent(res.sum.null <- summary(clv.cdnow, Id=NULL))
-  expect_silent(res.sum.all <- summary(clv.cdnow, Id=cdnow[, unique(Id)]))
+  expect_silent(res.sum.null <- summary(clv.cdnow, ids=NULL))
+  expect_silent(res.sum.all <- summary(clv.cdnow, ids=cdnow[, unique(Id)]))
   expect_true(isTRUE(all.equal(res.sum.null$descriptives.transactions,
                                res.sum.all$descriptives.transactions)))
 })
@@ -70,11 +70,11 @@ test_that("Same transaction summary if all ids or NULL are given", {
 test_that("Correct Ids selected", {
   skip_on_cran()
   clv.cdnow <- fct.helper.create.clvdata.cdnow(cdnow)
-  expect_silent(res.sum <- summary(clv.cdnow, Id=c("1", "2", "3")))
+  expect_silent(res.sum <- summary(clv.cdnow, ids=c("1", "2", "3")))
   expect_true(setequal(res.sum$selected.ids, c("1", "2", "3")))
   expect_true(length(unique(res.sum$selected.ids)) == length(res.sum$selected.ids))
   # double
-  expect_silent(res.sum <- summary(clv.cdnow, Id=c("1", "2", "3", "3", "3")))
+  expect_silent(res.sum <- summary(clv.cdnow, ids=c("1", "2", "3", "3", "3")))
   expect_true(setequal(res.sum$selected.ids, c("1", "2", "3")))
   expect_true(length(unique(res.sum$selected.ids)) == length(res.sum$selected.ids))
 })
@@ -82,8 +82,8 @@ test_that("Correct Ids selected", {
 test_that("Different output if ids given", {
   skip_on_cran()
   clv.cdnow <- fct.helper.create.clvdata.cdnow(cdnow)
-  expect_silent(df.desc.1 <- summary(clv.cdnow, Id="1")$descriptives.transactions)
-  expect_silent(df.desc.123 <- summary(clv.cdnow, Id=c("1", "2", "3" ,"99"))$descriptives.transactions)
+  expect_silent(df.desc.1 <- summary(clv.cdnow, ids="1")$descriptives.transactions)
+  expect_silent(df.desc.123 <- summary(clv.cdnow, ids=c("1", "2", "3" ,"99"))$descriptives.transactions)
 
   expect_false(isTRUE(all.equal(df.desc.1[, "Estimation"], df.desc.123[, "Estimation"])))
   expect_false(isTRUE(all.equal(df.desc.1[, "Holdout"], df.desc.123[, "Holdout"])))
@@ -93,7 +93,7 @@ test_that("Different output if ids given", {
 test_that("Holdout is - if customer has no transactions in holdout period", {
   skip_on_cran()
   clv.cdnow <- fct.helper.create.clvdata.cdnow(cdnow)
-  expect_true(all(summary(clv.cdnow, Id="2")$descriptives.transactions[, "Holdout"] == "-"))
+  expect_true(all(summary(clv.cdnow, ids="2")$descriptives.transactions[, "Holdout"] == "-"))
 })
 
 

--- a/tests/testthat/test_correctness_clvdata_s3.R
+++ b/tests/testthat/test_correctness_clvdata_s3.R
@@ -110,16 +110,16 @@ test_that("Correct data format is returned", {
 })
 
 
-test_that("Correct Ids are returned", {
+test_that("Correct ids are returned", {
   skip_on_cran()
   clv.cdnow <- fct.helper.create.clvdata.cdnow(data.cdnow=cdnow)
   target.ids <- c("1", "2", "999")
 
-  expect_setequal(as.data.frame(clv.cdnow, Ids = target.ids)$Id, target.ids)
-  expect_setequal(as.data.table(clv.cdnow, Ids = target.ids)$Id, target.ids)
+  expect_setequal(as.data.frame(clv.cdnow, ids = target.ids)$Id, target.ids)
+  expect_setequal(as.data.table(clv.cdnow, ids = target.ids)$Id, target.ids)
 
-  expect_warning(as.data.frame(clv.cdnow, Ids=c(target.ids, "abc")))
-  expect_warning(as.data.table(clv.cdnow, Ids=c(target.ids, "abc")))
+  expect_warning(as.data.frame(clv.cdnow, ids=c(target.ids, "abc")))
+  expect_warning(as.data.table(clv.cdnow, ids=c(target.ids, "abc")))
 })
 
 test_that("Returns correct number of transactinons for given sample", {
@@ -151,18 +151,18 @@ test_that("Always returns a copy", {
   expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="estimation")))
   expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="holdout")))
 
-  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="full", Ids = "1")))
-  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="estimation", Ids = "1")))
-  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="holdout", Ids = "1")))
+  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="full", ids = "1")))
+  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="estimation", ids = "1")))
+  expect_false(orig.address == address(as.data.frame(clv.cdnow, sample="holdout", ids = "1")))
 
   # data.table
   expect_false(orig.address == address(as.data.table(clv.cdnow, sample="full")))
   expect_false(orig.address == address(as.data.table(clv.cdnow, sample="estimation")))
   expect_false(orig.address == address(as.data.table(clv.cdnow, sample="holdout")))
 
-  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="full", Ids = "1")))
-  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="estimation", Ids = "1")))
-  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="holdout", Ids = "1")))
+  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="full", ids = "1")))
+  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="estimation", ids = "1")))
+  expect_false(orig.address == address(as.data.table(clv.cdnow, sample="holdout", ids = "1")))
 })
 
 

--- a/tests/testthat/test_inputchecks_clvdata_plot.R
+++ b/tests/testthat/test_inputchecks_clvdata_plot.R
@@ -99,13 +99,13 @@ test_that("timings - annotate.ids is valid", {
   expect_error(plot(clv.cdnow.nohold, which="timings", annotate.ids=c("1", "2")), regexp = "of type logical")
 })
 
-test_that("timings - Ids is valid", {
+test_that("timings - ids is valid", {
   skip_on_cran()
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=NA), regexp = "may not contain")
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=-1), regexp = "strictly positive")
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=0), regexp = "strictly positive")
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=1:10), regexp = "single number")
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=""), regexp = "empty text")
-  expect_error(plot(clv.cdnow.nohold, which="timings", Ids=c("1", "", "2")), regexp = "empty text")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=NA), regexp = "may not contain")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=-1), regexp = "strictly positive")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=0), regexp = "strictly positive")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=1:10), regexp = "single number")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=""), regexp = "empty text")
+  expect_error(plot(clv.cdnow.nohold, which="timings", ids=c("1", "", "2")), regexp = "empty text")
 })
 

--- a/tests/testthat/test_runability_clvdata_s3.R
+++ b/tests/testthat/test_runability_clvdata_s3.R
@@ -205,24 +205,24 @@ fct.helper.test.runability.clv.data.plotinterpurchasetime <- function(clv.data){
 }
 
 fct.helper.test.runability.clv.data.plottimings <- function(clv.data){
-  test_that("plot - timings, Ids", {
+  test_that("plot - timings, ids", {
     skip_on_cran()
-    expect_silent(plot(clv.data, which="timings", Ids = 1, verbose=FALSE))
-    expect_silent(plot(clv.data, which="timings", Ids = 5, verbose=FALSE))
-    expect_silent(plot(clv.data, which="timings", Ids = c("1"), verbose=FALSE))
-    expect_silent(plot(clv.data, which="timings", Ids = c("1", "10"), verbose=FALSE))
-    expect_silent(plot(clv.data, which="timings", Ids = nobs(clv.data), verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = 1, verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = 5, verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = c("1"), verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = c("1", "10"), verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = nobs(clv.data), verbose=FALSE))
   })
 
 
   test_that("plot - timings, annotate.ids", {
     skip_on_cran()
-    expect_silent(plot(clv.data, which="timings", Ids = 5, annotate.ids=TRUE, verbose=FALSE))
+    expect_silent(plot(clv.data, which="timings", ids = 5, annotate.ids=TRUE, verbose=FALSE))
   })
 
   test_that("plot - timings, plot=FALSE", {
     skip_on_cran()
-    expect_silent(dt.plot <- plot(clv.data, which="timings", Ids=c("1", "10"), plot=FALSE, verbose=FALSE))
+    expect_silent(dt.plot <- plot(clv.data, which="timings", ids=c("1", "10"), plot=FALSE, verbose=FALSE))
     expect_s3_class(dt.plot, "data.table")
     expect_setequal(colnames(dt.plot), c("Id", "type", "variable", "value"))
     expect_setequal(dt.plot$Id, c("1", "10"))

--- a/tests/testthat/test_runability_clvdata_s3.R
+++ b/tests/testthat/test_runability_clvdata_s3.R
@@ -24,7 +24,7 @@ fct.helper.test.runability.clv.data.summary <- function(clv.data){
     expect_silent(summary(clv.data, ids=id, sample="estimation"))
 
     # multiple ids
-    ids <- clv.data@data.transactions[, head(unique(ids), n=5)]
+    ids <- clv.data@data.transactions[, head(unique(Id), n=5)]
     expect_silent(summary(clv.data, ids=ids))
     expect_silent(summary(clv.data, ids=ids, sample="estimation"))
 

--- a/tests/testthat/test_runability_clvdata_s3.R
+++ b/tests/testthat/test_runability_clvdata_s3.R
@@ -20,25 +20,25 @@ fct.helper.test.runability.clv.data.summary <- function(clv.data){
   test_that("summary for selected customers works", {
     # single id
     id <- clv.data@data.transactions[, head(unique(Id), n=1)]
-    expect_silent(summary(clv.data, Id=id))
-    expect_silent(summary(clv.data, Id=id, sample="estimation"))
+    expect_silent(summary(clv.data, ids=id))
+    expect_silent(summary(clv.data, ids=id, sample="estimation"))
 
     # multiple ids
-    ids <- clv.data@data.transactions[, head(unique(Id), n=5)]
-    expect_silent(summary(clv.data, Id=ids))
-    expect_silent(summary(clv.data, Id=ids, sample="estimation"))
+    ids <- clv.data@data.transactions[, head(unique(ids), n=5)]
+    expect_silent(summary(clv.data, ids=ids))
+    expect_silent(summary(clv.data, ids=ids, sample="estimation"))
 
-    # warning if inexistent Id
-    expect_warning(summary(clv.data, Id=c(ids, "abczxy")), regexp = "Not all given Ids were found")
+    # warning if inexistent ids
+    expect_warning(summary(clv.data, ids=c(ids, "abczxy")), regexp = "Not all given ids were found")
 
     # id with trans in holdout
     expect_silent(id.with.holdout <- clv.data@data.transactions[Date>=clv.data@clv.time@timepoint.holdout.start, head(Id,n=1)])
-    expect_silent(summary(clv.data, Id=id.with.holdout))
+    expect_silent(summary(clv.data, ids=id.with.holdout))
 
     # id without trans in holdout
     #   any zero-repeater
     expect_silent(single.zero.rep <- clv.data@data.transactions[, .N, by="Id"][N==1][,head(Id,n=1)])
-    expect_silent(summary(clv.data, Id=single.zero.rep))
+    expect_silent(summary(clv.data, ids=single.zero.rep))
   })
 }
 


### PR DESCRIPTION
- lowercase for consistency with other parameters in the same methods
- plural for consistency with other methods (nameS.cov.life vs name.date, trans.binS, etc)
