### PR TITLE
Bootstrapping: Store call args in object

### DIFF
--- a/R/all_generics.R
+++ b/R/all_generics.R
@@ -79,11 +79,6 @@ setGeneric("clv.fitted.estimate.same.specification.on.new.data", function(clv.fi
   standardGeneric("clv.fitted.estimate.same.specification.on.new.data")
 })
 
-# Method to collect the args used when estimating the model. Allows to re-estimate the model
-setGeneric("clv.fitted.get.model.estimation.interface.args", function(clv.fitted){
-  standardGeneric("clv.fitted.get.model.estimation.interface.args")
-})
-
 # Generate many predictions by re-fitting the given model on bootstrapped
 # transaction data and predicting on it
 setGeneric("clv.fitted.bootstrap.predictions", function(clv.fitted, num.boots, verbose, ...){

--- a/R/all_generics.R
+++ b/R/all_generics.R
@@ -17,7 +17,7 @@ setGeneric(name = "predict")
 setGeneric("clv.controlflow.estimate.check.inputs", def=function(clv.fitted,  start.params.model, optimx.args, verbose,...)
   standardGeneric("clv.controlflow.estimate.check.inputs"))
 
-setGeneric("clv.controlflow.estimate.put.inputs", def=function(clv.fitted, verbose, ...)
+setGeneric("clv.controlflow.estimate.put.inputs", def=function(clv.fitted, start.params.model, optimx.args, verbose, ...)
   standardGeneric("clv.controlflow.estimate.put.inputs"))
 
 setGeneric("clv.controlflow.estimate.generate.start.params", def=function(clv.fitted, start.params.model, verbose,...)

--- a/R/class_clv_fitted.R
+++ b/R/class_clv_fitted.R
@@ -16,6 +16,7 @@ setOldClass("optimx")
 #' @slot call Single language of the call used to create the object
 #' @slot clv.model Single object of (sub-) class \code{clv.model} that determines model-specific behavior.
 #' @slot clv.data Single object of (sub-) class \code{clv.data} that contains the data and temporal information to fit the model to.
+#' @slot model.specification.args Model specification given by the user with which the model was fit. Used to re-fit the model on new data (bootstrapping).
 #' @slot prediction.params.model Numeric vector of the model parameters, set and used solely when predicting. Named after model parameters in original scale and derived from \code{coef()}.
 #' @slot optimx.estimation.output A single object of class \code{optimx} as returned from method \code{optimx::optimx} after optimizing the log-likelihood fitting the model.
 #' @slot optimx.hessian Single matrix that is the hessian extracted from the last row of the optimization output stored in the slot \code{optimx.estimation.output}.
@@ -30,6 +31,7 @@ setClass(Class = "clv.fitted", contains = "VIRTUAL",
            call      = "language",
            clv.model = "clv.model",
            clv.data  = "clv.data",
+           model.specification.args = "list",
 
            prediction.params.model = "numeric",
 
@@ -40,6 +42,7 @@ setClass(Class = "clv.fitted", contains = "VIRTUAL",
 
          # Prototype is labeled not useful anymore, but still recommended by Hadley / Bioc
          prototype = list(
+           model.specification.args = list(),
            prediction.params.model = numeric(0),
 
            optimx.estimation.output = structure(data.frame(), class="optimx"),

--- a/R/class_clv_fitted_spending.R
+++ b/R/class_clv_fitted_spending.R
@@ -40,6 +40,3 @@ setMethod(f = "clv.controlflow.estimate.check.inputs", signature = signature(clv
   check_err_msg(err.msg)
 })
 
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.fitted.spending", def = function(clv.fitted){
-  return(list(remove.first.transaction=clv.fitted@estimation.removed.first.transaction))
-})

--- a/R/class_clv_pnbd.R
+++ b/R/class_clv_pnbd.R
@@ -81,11 +81,3 @@ setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitt
 
   return(clv.fitted)
 })
-
-
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.pnbd", def = function(clv.fitted){
-  args <- callNextMethod()
-  return(c(args, list(
-    use.cor=clv.fitted@clv.model@estimation.used.correlation
-  )))
-})

--- a/R/class_clv_pnbd.R
+++ b/R/class_clv_pnbd.R
@@ -69,6 +69,19 @@ pnbd_cbs <- function(clv.data){
 }
 
 
+setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitted="clv.pnbd"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, use.cor, start.param.cor, ...){
+  # For PNBD models, need to also store args related to correlation which no other model has.
+  # This is required for all PNBD classes as they do not inherit from each other.
+  clv.fitted <- callNextMethod()
+
+  clv.fitted@model.specification.args <- c(clv.fitted@model.specification.args, list(
+    use.cor=use.cor,
+    start.param.cor=start.param.cor
+  ))
+
+  return(clv.fitted)
+})
+
 
 setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.pnbd", def = function(clv.fitted){
   args <- callNextMethod()

--- a/R/class_clv_pnbd_dynamiccov.R
+++ b/R/class_clv_pnbd_dynamiccov.R
@@ -66,12 +66,3 @@ pnbd_dyncov_cbs <- function(clv.data){
   return(dt.cbs)
 }
 
-
-
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.pnbd.dynamic.cov", def = function(clv.fitted){
-  args <- callNextMethod()
-  return(c(args, list(
-    use.cor=clv.fitted@clv.model@estimation.used.correlation
-  )))
-})
-

--- a/R/class_clv_pnbd_staticcov.R
+++ b/R/class_clv_pnbd_staticcov.R
@@ -35,3 +35,17 @@ setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.pnb
     use.cor=clv.fitted@clv.model@estimation.used.correlation
   )))
 })
+
+
+
+setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitted="clv.pnbd.static.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, use.cor, start.param.cor, ...){
+
+  clv.fitted <- callNextMethod()
+
+  clv.fitted@model.specification.args <- c(clv.fitted@model.specification.args, list(
+    use.cor=use.cor,
+    start.param.cor=start.param.cor
+  ))
+
+  return(clv.fitted)
+})

--- a/R/class_clv_pnbd_staticcov.R
+++ b/R/class_clv_pnbd_staticcov.R
@@ -29,14 +29,6 @@ clv.pnbd.static.cov <- function(cl, clv.data){
              cbs = dt.cbs.pnbd))
 }
 
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.pnbd.static.cov", def = function(clv.fitted){
-  args <- callNextMethod()
-  return(c(args, list(
-    use.cor=clv.fitted@clv.model@estimation.used.correlation
-  )))
-})
-
-
 
 setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitted="clv.pnbd.static.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, use.cor, start.param.cor, ...){
 

--- a/R/clv_template_controlflow_estimate.R
+++ b/R/clv_template_controlflow_estimate.R
@@ -14,7 +14,7 @@ clv.template.controlflow.estimate <- function(clv.fitted,
 
 
   # Store user input for estimation ----------------------------------------------------------------------------
-  clv.fitted           <- clv.controlflow.estimate.put.inputs(clv.fitted=clv.fitted, verbose=verbose, ...)
+  clv.fitted           <- clv.controlflow.estimate.put.inputs(clv.fitted=clv.fitted, start.params.model=start.params.model, optimx.args=optimx.args, verbose=verbose, ...)
   clv.fitted@clv.model <- clv.model.put.estimation.input(clv.model=clv.fitted@clv.model, ...)
 
 

--- a/R/f_generics_clvfitted.R
+++ b/R/f_generics_clvfitted.R
@@ -23,9 +23,7 @@ setMethod(f = "clv.controlflow.predict.set.prediction.params", signature = signa
 setMethod("clv.fitted.estimate.same.specification.on.new.data", signature = "clv.fitted", def = function(clv.fitted, newdata, ...){
   cl <- match.call(expand.dots = TRUE)
 
-  args <- clv.fitted.get.model.estimation.interface.args(clv.fitted)
-
-  args <- c(args, list(clv.data=newdata))
+  args <- c(clv.fitted@model.specification.args, list(clv.data=newdata))
 
   # overwrite with what was passed
   args <- modifyList(args, val = list(...), keep.null = TRUE)

--- a/R/f_generics_clvfitted_estimate.R
+++ b/R/f_generics_clvfitted_estimate.R
@@ -20,9 +20,11 @@ setMethod(f = "clv.controlflow.estimate.check.inputs", signature = signature(clv
 })
 
 # . clv.controlflow.estimate.put.inputs ------------------------------------------------------------------------
-setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitted="clv.fitted"), definition = function(clv.fitted, verbose, ...){
+setMethod("clv.controlflow.estimate.put.inputs", signature =  signature(clv.fitted="clv.fitted"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, ...){
+  clv.fitted@model.specification.args <- list(start.params.model=start.params.model, optimx.args=optimx.args, verbose=verbose)
   return(clv.fitted)
 })
+
 
 
 # . clv.controlflow.estimate.generate.start.params ------------------------------------------------------------------------

--- a/R/f_generics_clvfittedspending.R
+++ b/R/f_generics_clvfittedspending.R
@@ -1,6 +1,8 @@
 # . clv.controlflow.estimate.put.inputs -----------------------------------------------------------------
-setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.fitted.spending"), definition = function(clv.fitted, verbose, remove.first.transaction, ...){
+setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.fitted.spending"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, remove.first.transaction, ...){
   clv.fitted <- callNextMethod()
+
+  clv.fitted@model.specification.args[["remove.first.transaction"]] <- remove.first.transaction
 
   clv.fitted@estimation.removed.first.transaction <- remove.first.transaction
   return(clv.fitted)

--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -339,12 +339,6 @@ setMethod("clv.controlflow.predict.new.customer", signature = signature(clv.fitt
     t=clv.newcustomer@num.periods)))
 })
 
-# .clv.fitted.get.model.estimation.interface.args --------------------------------------------
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.fitted.transactions", def = function(clv.fitted){
-  # For many models there are no specifc args available (e.g nocov bgnbd and ggomnbd)
-  return(list())
-})
-
 
 # . clv.fitted.bootstrap.predictions --------------------------------------------
 setMethod(f = "clv.fitted.bootstrap.predictions", signature = signature(clv.fitted="clv.fitted.transactions"), definition = function(clv.fitted, num.boots, verbose, prediction.end, predict.spending, continuous.discount.factor){

--- a/R/f_generics_clvfittedtransactionsstaticcov.R
+++ b/R/f_generics_clvfittedtransactionsstaticcov.R
@@ -98,14 +98,5 @@ setMethod(f = "clv.controlflow.predict.new.customer", signature = signature(clv.
     t=clv.newcustomer@num.periods)))
 })
 
-# . clv.fitted.get.model.estimation.interface.args -------------------------------------------------------------
-setMethod("clv.fitted.get.model.estimation.interface.args", signature = "clv.fitted.transactions.static.cov", def = function(clv.fitted){
-  # TODO [Test]: returns correct args if using additional specifications (one object fit with all additional options)
 
-  # estimation args available for all (static & dyn) cov models
-  return(list(
-    names.cov.constr = if(clv.fitted@estimation.used.constraints){clv.fitted@names.original.params.constr}else{c()},
-    reg.lambdas = if(clv.fitted@estimation.used.regularization){c(trans=clv.fitted@reg.lambda.trans, life=clv.fitted@reg.lambda.life)}else{c()}
-  ))
-})
 

--- a/R/f_generics_clvfittedtransactionsstaticcov_estimate.R
+++ b/R/f_generics_clvfittedtransactionsstaticcov_estimate.R
@@ -50,7 +50,7 @@ setMethod(f = "clv.controlflow.estimate.check.inputs", signature = signature(clv
 
 # . clv.controlflow.estimate.put.inputs ------------------------------------------------------------------------------
 #' @importFrom methods callNextMethod
-setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.fitted.transactions.static.cov"), definition = function(clv.fitted, verbose, reg.lambdas, names.cov.constr, names.cov.life, names.cov.trans, ...){
+setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.fitted.transactions.static.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, reg.lambdas, names.cov.constr, names.cov.life, names.cov.trans, start.params.constr, start.params.life, start.params.trans, ...){
 
   # clv.fitted put inputs
   clv.fitted <- callNextMethod()
@@ -58,6 +58,18 @@ setMethod("clv.controlflow.estimate.put.inputs", signature = signature(clv.fitte
   # Reduce to user's desired covariates only -----------------------------------------------------------
   clv.fitted@clv.data <- clv.data.reduce.covariates(clv.data=clv.fitted@clv.data, names.cov.life=names.cov.life,
                                                     names.cov.trans=names.cov.trans)
+
+  # store model specification ------------------------------------------------------------------------
+  # only related to static covs
+  clv.fitted@model.specification.args <- c(clv.fitted@model.specification.args, list(
+    names.cov.life=names.cov.life,
+    names.cov.trans=names.cov.trans,
+    start.params.life=start.params.life,
+    start.params.trans=start.params.trans,
+    names.cov.constr=names.cov.constr,
+    start.params.constr=start.params.constr,
+    reg.lambdas=reg.lambdas
+  ))
 
   # is regularization used? ---------------------------------------------------------------------------
   #   Yes:  Indicate and store lambdas

--- a/R/f_generics_clvpnbddyncov.R
+++ b/R/f_generics_clvpnbddyncov.R
@@ -50,9 +50,14 @@ setMethod("clv.controlflow.estimate.generate.start.params", signature = signatur
 
 # . clv.model.put.estimation.input ------------------------------------------------------------------------------------------------
 
-setMethod(f = "clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.pnbd.dynamic.cov"), definition = function(clv.fitted, verbose, ...){
+setMethod(f = "clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.pnbd.dynamic.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, ...){
   # Create walks - they are specific to the pnbd dyncov model
   clv.fitted <- callNextMethod()
+
+  clv.fitted@model.specification.args <- c(clv.fitted@model.specification.args, list(
+    use.cor=use.cor,
+    start.param.cor=start.param.cor
+  ))
 
   if(verbose)
     message("Creating walks...")

--- a/R/f_generics_clvpnbddyncov.R
+++ b/R/f_generics_clvpnbddyncov.R
@@ -50,7 +50,7 @@ setMethod("clv.controlflow.estimate.generate.start.params", signature = signatur
 
 # . clv.model.put.estimation.input ------------------------------------------------------------------------------------------------
 
-setMethod(f = "clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.pnbd.dynamic.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, ...){
+setMethod(f = "clv.controlflow.estimate.put.inputs", signature = signature(clv.fitted="clv.pnbd.dynamic.cov"), definition = function(clv.fitted, start.params.model, optimx.args, verbose, use.cor, start.param.cor, ...){
   # Create walks - they are specific to the pnbd dyncov model
   clv.fitted <- callNextMethod()
 

--- a/R/f_interface_bootstrappedapply.R
+++ b/R/f_interface_bootstrappedapply.R
@@ -5,7 +5,8 @@
 #' Given a fitted model, sample new data from the \code{clv.data} stored in it and re-fit the model on it.
 #' Which customers are selected into the new data is determined by \code{fn.sample}.
 #' The model is fit on the new data with the same options with which it was originally fit,
-#' excluding \code{optimx.args} and \code{verbose} (if required, these can be passed as \code{...}).
+#' including \code{optimx.args}, \code{verbose} and start parameters. If required,
+#' any option can be changed by passing it as \code{...}.
 #' After the model is fit, \code{fn.boot.apply} is applied to it and
 #' the value it returns is collected in a list which is eventually returned.
 #'

--- a/man/clv.bootstrapped.apply.Rd
+++ b/man/clv.bootstrapped.apply.Rd
@@ -25,7 +25,8 @@ Returns a list containing the results of \code{fn.boot.apply}
 Given a fitted model, sample new data from the \code{clv.data} stored in it and re-fit the model on it.
 Which customers are selected into the new data is determined by \code{fn.sample}.
 The model is fit on the new data with the same options with which it was originally fit,
-excluding \code{optimx.args} and \code{verbose} (if required, these can be passed as \code{...}).
+including \code{optimx.args}, \code{verbose} and start parameters. If required,
+any option can be changed by passing it as \code{...}.
 After the model is fit, \code{fn.boot.apply} is applied to it and
 the value it returns is collected in a list which is eventually returned.
 

--- a/man/clv.fitted-class.Rd
+++ b/man/clv.fitted-class.Rd
@@ -25,6 +25,8 @@ Created with an existing clv.data and clv.model object (or subclasses thereof).
 
 \item{\code{clv.data}}{Single object of (sub-) class \code{clv.data} that contains the data and temporal information to fit the model to.}
 
+\item{\code{model.specification.args}}{Model specification given by the user with which the model was fit. Used to re-fit the model on new data (bootstrapping).}
+
 \item{\code{prediction.params.model}}{Numeric vector of the model parameters, set and used solely when predicting. Named after model parameters in original scale and derived from \code{coef()}.}
 
 \item{\code{optimx.estimation.output}}{A single object of class \code{optimx} as returned from method \code{optimx::optimx} after optimizing the log-likelihood fitting the model.}


### PR DESCRIPTION
Replace collecting method call args from the fitted models properties (`clv.fitted.get.model.estimation.interface.args`) with a list which explicitly stores them when estimating the model. This allows to store args such as optimx.args or start parameters and re-use them again when bootstrapping.