### PR TITLE
RcppArmadillo: Native vec methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ License: GPL-3
 URL: https://github.com/bachmannpatrick/CLVTools
 BugReports: https://github.com/bachmannpatrick/CLVTools/issues
 NeedsCompilation: yes
-LinkingTo: Rcpp, RcppArmadillo (>= 0.9.500.2.0), RcppGSL (>= 0.3.7), testthat
+LinkingTo: Rcpp, RcppArmadillo (>= 0.11.4.0.1), RcppGSL (>= 0.3.7), testthat
 LazyLoad: yes
 Encoding: UTF-8
 Collate: 

--- a/src/bgnbd.cpp
+++ b/src/bgnbd.cpp
@@ -47,9 +47,9 @@ arma::vec bgnbd_nocov_CET(const double r,
 
   // Build alpha and beta --------------------------------------------------------
   //    No covariates: Same alphas, betas for every customer
-  const arma::vec vA_i = clv::vec_fill(a, vX.n_elem);
-  const arma::vec vB_i = clv::vec_fill(b, vX.n_elem);
-  const arma::vec vAlpha_i = clv::vec_fill(alpha, vX.n_elem);
+  const arma::vec vA_i = arma::vec(vX.n_elem, arma::fill::value(a));
+  const arma::vec vB_i = arma::vec(vX.n_elem, arma::fill::value(b));
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha));
 
   return bgnbd_CET(r, vAlpha_i, vA_i, vB_i, dPeriods, vX, vT_x, vT_cal);
 }
@@ -99,7 +99,7 @@ arma::vec bgnbd_expectation(const double r,
                             const arma::vec& vA_i,
                             const arma::vec& vB_i,
                             const arma::vec& vT_i){
-  const arma::vec vR = clv::vec_fill(r, vAlpha_i.n_elem);
+  const arma::vec vR = arma::vec(vAlpha_i.n_elem, arma::fill::value(r));
 
   const arma::vec term1 = (vA_i + vB_i - 1)/(vA_i - 1);
   const arma::vec term2 = arma::pow((vAlpha_i / (vAlpha_i + vT_i)),r);
@@ -117,9 +117,9 @@ arma::vec bgnbd_nocov_expectation(const double r,
                                   const arma::vec& vT_i){
 
   // Build alpha and beta --------------------------------------------------------
-  const arma::vec vA_i = clv::vec_fill(a, vT_i.n_elem);
-  const arma::vec vB_i = clv::vec_fill(b, vT_i.n_elem);
-  const arma::vec vAlpha_i = clv::vec_fill(alpha, vT_i.n_elem);
+  const arma::vec vA_i = arma::vec(vT_i.n_elem, arma::fill::value(a));
+  const arma::vec vB_i = arma::vec(vT_i.n_elem, arma::fill::value(b));
+  const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha));
 
   return bgnbd_expectation(r,
                            vAlpha_i,
@@ -188,9 +188,9 @@ arma::vec bgnbd_nocov_PAlive(const double r,
 
   // Build alpha, a and b --------------------------------------------------------
   //    No covariates: Same alpha, a and b for every customer
-  const arma::vec vA_i = clv::vec_fill(a, vX.n_elem);
-  const arma::vec vB_i = clv::vec_fill(b, vX.n_elem);
-  const arma::vec vAlpha_i = clv::vec_fill(alpha, vX.n_elem);
+  const arma::vec vA_i = arma::vec(vX.n_elem, arma::fill::value(a));
+  const arma::vec vB_i = arma::vec(vX.n_elem, arma::fill::value(b));
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha));
 
   return bgnbd_PAlive(r,
                       vAlpha_i,
@@ -277,9 +277,9 @@ arma::vec bgnbd_nocov_LL_ind(const arma::vec& vLogparams,
   const double a_0       = std::exp(vLogparams(2));
   const double b_0       = std::exp(vLogparams(3));
 
-  const arma::vec vA_i = clv::vec_fill(a_0, vX.n_elem);
-  const arma::vec vB_i = clv::vec_fill(b_0, vX.n_elem);
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
+  const arma::vec vA_i = arma::vec(vX.n_elem, arma::fill::value(a_0));
+  const arma::vec vB_i = arma::vec(vX.n_elem, arma::fill::value(b_0));
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
 
   arma::vec vLL = bgnbd_LL_ind(r, vAlpha_i, vA_i, vB_i, vX, vT_x, vT_cal);
 
@@ -407,9 +407,9 @@ arma::vec bgnbd_nocov_PMF(const double r,
                           const unsigned int x,
                           const arma::vec& vT_i){
 
-  const arma::vec vA_i = clv::vec_fill(a, vT_i.n_elem);
-  const arma::vec vB_i = clv::vec_fill(b, vT_i.n_elem);
-  const arma::vec vAlpha_i = clv::vec_fill(alpha, vT_i.n_elem);
+  const arma::vec vA_i = arma::vec(vT_i.n_elem, arma::fill::value(a));
+  const arma::vec vB_i = arma::vec(vT_i.n_elem, arma::fill::value(b));
+  const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha));
 
   return(bgnbd_PMF(r, x,
                    vAlpha_i,vA_i,vB_i,

--- a/src/bgnbd.cpp
+++ b/src/bgnbd.cpp
@@ -28,8 +28,8 @@ arma::vec bgnbd_CET(const double r,
                     const arma::vec& vT_cal){
 
   const arma::vec term1 = ((vA_i + vB_i + vX - 1) / (vA_i - 1));
-  const arma::vec term2 = 1 - clv::vec_pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_cal + dPeriods), (r + vX)) % clv::vec_hyp2F1((r + vX), (vB_i + vX), (vA_i + vB_i + vX - 1), dPeriods / (vAlpha_i + vT_cal + dPeriods));
-  const arma::vec term3 = 1 + (vX > 0) % (vA_i /(vB_i + vX - 1)) % clv::vec_pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_x), (r + vX));
+  const arma::vec term2 = 1 - arma::pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_cal + dPeriods), (r + vX)) % clv::vec_hyp2F1((r + vX), (vB_i + vX), (vA_i + vB_i + vX - 1), dPeriods / (vAlpha_i + vT_cal + dPeriods));
+  const arma::vec term3 = 1 + (vX > 0) % (vA_i /(vB_i + vX - 1)) % arma::pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_x), (r + vX));
 
   return term1 % term2 / term3;
 }
@@ -171,7 +171,7 @@ arma::vec bgnbd_PAlive(const double r,
                        const arma::vec& vX,
                        const arma::vec& vT_x,
                        const arma::vec& vT_cal){
-  const arma::vec n_term1 = (vA_i/(vB_i + vX - 1)) % clv::vec_pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_x), (r+vX));
+  const arma::vec n_term1 = (vA_i/(vB_i + vX - 1)) % arma::pow((vAlpha_i + vT_cal)/(vAlpha_i + vT_x), (r+vX));
 
   return (1 / (1 + (vX > 0) % n_term1));
 }
@@ -258,7 +258,7 @@ arma::vec bgnbd_LL_ind(const double r,
 
   const arma::vec vPart1 = r * arma::log(vAlpha_i) + arma::lgamma(r + vX) - std::lgamma(r) - (r + vX) % arma::log(vAlpha_i + vT_x);
 
-  const arma::vec vPart2 = beta_ratio(vA_i, (vB_i+vX), vA_i, vB_i) % clv::vec_pow((vAlpha_i + vT_x)/(vAlpha_i + vT_cal), (r + vX)) + ((vX > 0)) % beta_ratio(vA_i + 1 , (vB_i + vX - 1), vA_i, vB_i);
+  const arma::vec vPart2 = beta_ratio(vA_i, (vB_i+vX), vA_i, vB_i) % arma::pow((vAlpha_i + vT_x)/(vAlpha_i + vT_cal), (r + vX)) + ((vX > 0)) % beta_ratio(vA_i + 1 , (vB_i + vX - 1), vA_i, vB_i);
 
   const arma::vec vLL = vPart1 + arma::log(vPart2);
 

--- a/src/clv_vectorized.cpp
+++ b/src/clv_vectorized.cpp
@@ -106,23 +106,6 @@ arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX){
 }
 
 
-// vec_pow --------------------------------------------------------
-//    element-by-element pow of the two given vectors
-arma::vec vec_pow(const arma::vec& vA, const arma::vec& vP){
-  arma::vec vRes(vA);
-  arma::vec::const_iterator it_a = vA.begin(), it_p = vP.begin(), it_a_end = vA.end();
-  arma::vec::iterator it_res = vRes.begin();
-
-  while(it_a != it_a_end){
-    (*it_res) = std::pow(*it_a, *it_p);
-    it_a++;
-    it_p++;
-    it_res++;
-  }
-
-  return(vRes);
-}
-
 arma::vec vec_fill(const double d, const arma::uword n){
   arma::vec vResult(n);
   vResult.fill(d);

--- a/src/clv_vectorized.cpp
+++ b/src/clv_vectorized.cpp
@@ -105,14 +105,6 @@ arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX){
   return(vRes);
 }
 
-
-arma::vec vec_fill(const double d, const arma::uword n){
-  arma::vec vResult(n);
-  vResult.fill(d);
-  return vResult;
-}
-
-
 // lbeta := lgamma(a) + lgamma(b) - lgamma(a+b)
 arma::vec vec_lbeta(const arma::vec& a, const double b){
   return (arma::lgamma(a) + std::lgamma(b) - arma::lgamma(a+b));

--- a/src/clv_vectorized.h
+++ b/src/clv_vectorized.h
@@ -17,8 +17,6 @@ arma::vec vec_hyp2F1(const arma::vec& vA, const arma::vec& vB, const arma::vec& 
 
 arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX);
 
-arma::vec vec_pow(const arma::vec& vA, const arma::vec& vP);
-
 arma::vec vec_fill(const double d, const arma::uword n);
 
 arma::vec vec_lbeta(const arma::vec& a, const double b);

--- a/src/clv_vectorized.h
+++ b/src/clv_vectorized.h
@@ -17,8 +17,6 @@ arma::vec vec_hyp2F1(const arma::vec& vA, const arma::vec& vB, const arma::vec& 
 
 arma::vec vec_x_kummerU(const double a, const double b, const arma::vec& vX);
 
-arma::vec vec_fill(const double d, const arma::uword n);
-
 arma::vec vec_lbeta(const arma::vec& a, const double b);
 
 double lbeta(const double a, const double b);

--- a/src/ggomnbd.cpp
+++ b/src/ggomnbd.cpp
@@ -114,7 +114,7 @@ arma::vec ggomnbd_CET(const double r,
   const arma::vec vIntegral = ggomnbd_integrate(r, b, s, vAlpha_i, vBeta_i,vX,
                                                 &ggomnbd_CET_integrand,
                                                 vT_x, vT_cal);
-  const arma::vec vLower = b * s * (1.0 + (b * s) * clv::vec_pow(vAlpha_i + vT_cal, r + vX) % arma::pow(vExpbTpart, s) % vIntegral);
+  const arma::vec vLower = b * s * (1.0 + (b * s) * arma::pow(vAlpha_i + vT_cal, r + vX) % arma::pow(vExpbTpart, s) % vIntegral);
   const arma::vec vFront = (r + vX)/(vAlpha_i + vT_cal);
 
   return(vFront % vUpper / vLower);

--- a/src/ggomnbd.cpp
+++ b/src/ggomnbd.cpp
@@ -133,8 +133,8 @@ arma::vec ggomnbd_nocov_CET(const double r,
                             const arma::vec& vT_x,
                             const arma::vec& vT_cal){
 
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
   return(ggomnbd_CET(r,b,s,dPeriods,vX,vT_x,vT_cal,vAlpha_i, vBeta_i));
 }
@@ -225,9 +225,9 @@ arma::vec ggomnbd_nocov_expectation(const double r,
                                     const double beta_0,
                                     const arma::vec& vT_i){
 
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vT_i.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vT_i.n_elem);
-  const arma::vec vR = clv::vec_fill(r, vT_i.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vT_i.n_elem, arma::fill::value(beta_0));
+  const arma::vec vR = arma::vec(vT_i.n_elem, arma::fill::value(r));
 
   return(ggomnbd_expectation(b,
                              s,
@@ -245,7 +245,7 @@ arma::vec ggomnbd_staticcov_expectation(const double r,
                                         const arma::vec& vAlpha_i,
                                         const arma::vec& vBeta_i,
                                         const arma::vec& vT_i){
-  const arma::vec vR = clv::vec_fill(r, vT_i.n_elem);
+  const arma::vec vR = arma::vec(vT_i.n_elem, arma::fill::value(r));
 
   return(ggomnbd_expectation(b,
                              s,
@@ -386,8 +386,8 @@ arma::vec ggomnbd_nocov_LL_ind(const arma::vec& vLogparams,
   const double s       = std::exp(vLogparams(3));
   const double beta_0  = std::exp(vLogparams(4));
 
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
   return(ggomnbd_LL_ind(r, b, s, vAlpha_i, vBeta_i, vX, vT_x, vT_cal));
 }
@@ -554,8 +554,8 @@ arma::vec ggomnbd_nocov_PAlive(const double r,
                                const arma::vec& vT_x,
                                const arma::vec& vT_cal){
 
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
   return ggomnbd_PAlive(r,b,s,vX,vT_x,vT_cal,vAlpha_i,vBeta_i);
 }
@@ -624,9 +624,9 @@ arma::vec ggomnbd_PMF(const double r,
   // TODO: Uses wrong limit=0 in integration routine which is smaller than the
   // workspace. This is a strong case to write dedicated routine.
   const arma::vec vIntergral = ggomnbd_integrate(r, b, s, vAlpha_i, vBeta_i,
-                                                 clv::vec_fill(x, vT_i.n_elem),
+                                                 arma::vec(vT_i.n_elem, arma::fill::value(x)),
                                                  &ggomnbd_PMF_integrand,
-                                                 clv::vec_fill(0.0, vT_i.n_elem), vT_i);
+                                                 arma::vec(vT_i.n_elem, arma::fill::zeros), vT_i);
 
   return vFront % (vInner + b * s * vIntergral);
 }
@@ -641,8 +641,8 @@ arma::vec ggomnbd_nocov_PMF(const double r,
                             const unsigned int x,
                             const arma::vec& vT_i){
 
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vT_i.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vT_i.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vT_i.n_elem, arma::fill::value(beta_0));
 
   return(ggomnbd_PMF(r,b,s,x,vAlpha_i,vBeta_i,vT_i));
 }

--- a/src/pnbd.cpp
+++ b/src/pnbd.cpp
@@ -50,8 +50,8 @@ arma::vec pnbd_nocov_CET(const double r,
 
   // Build alpha and beta --------------------------------------------------------
   //    No covariates: Same alphas, betas for every customer
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
 
   // Calculate PAlive -------------------------------------------------------------
@@ -185,8 +185,8 @@ arma::vec pnbd_nocov_DERT(const double r,
 
   // Build alpha and beta -------------------------------------------
   //    No covariates: Same alphas, betas for every customer
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
   // Calculate DERT -------------------------------------------------
   return pnbd_DERT_ind(r, s,
@@ -261,8 +261,8 @@ arma::vec pnbd_nocov_expectation(const double r,
                                  const arma::vec& vT_i){
 
   // Build alpha and beta --------------------------------------------------------
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vT_i.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vT_i.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vT_i.n_elem, arma::fill::value(beta_0));
 
   return(pnbd_expectation(r,
                           s,
@@ -361,7 +361,7 @@ arma::vec pnbd_LL_ind(const double r,
   //    2F1 4th param z: Use larger, subtract smaller
   //      use Max(alpha, beta) and abs(alpha-beta)
 
-  arma::vec vHyp2f1ParamB = clv::vec_fill(s + 1.0, n);
+  arma::vec vHyp2f1ParamB = arma::vec(n, arma::fill::value(s + 1.0));
   arma::uvec uvAlphaSmallerBeta = find(vAlpha_i < vBeta_i);
   vHyp2f1ParamB(uvAlphaSmallerBeta) = (r + vX(uvAlphaSmallerBeta));
 
@@ -441,8 +441,8 @@ arma::vec pnbd_nocov_LL_ind(const arma::vec& vLogparams,
 
   // Build alpha and beta --------------------------------------------
   //    No covariates: Same alphas, betas for every customer
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
   arma::vec vLL = pnbd_LL_ind(r, s, vAlpha_i, vBeta_i, vX, vT_x, vT_cal);
   return(vLL);
@@ -590,8 +590,8 @@ arma::vec pnbd_nocov_PAlive(const double r,
 
   // Build alpha and beta --------------------------------------------------------
   //    No covariates: Same alphas, betas for every customer
-  const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vX.n_elem);
-  const arma::vec vBeta_i = clv::vec_fill(beta_0, vX.n_elem);
+  const arma::vec vAlpha_i = arma::vec(vX.n_elem, arma::fill::value(alpha_0));
+  const arma::vec vBeta_i = arma::vec(vX.n_elem, arma::fill::value(beta_0));
 
 
   // Calculate PAlive -------------------------------------------------------------
@@ -666,10 +666,10 @@ arma::vec pnbd_PMF(const double r,
 
   const arma::vec vAbsAB = arma::abs(vAlpha_i - vBeta_i);
   const arma::vec vMaxAB = arma::max(vAlpha_i, vBeta_i);
-  const arma::vec vRS = clv::vec_fill(r+s, vAlpha_i.n_elem);
+  const arma::vec vRS = arma::vec(vAlpha_i.n_elem, arma::fill::value(r+s));
   const arma::vec vRSX1 = vRS + x + 1.0;
 
-  arma::vec vHypArgB = clv::vec_fill(r + x, vAlpha_i.n_elem);
+  arma::vec vHypArgB = arma::vec(vAlpha_i.n_elem, arma::fill::value(r + x));
   vHypArgB(find(vAlpha_i >= vBeta_i)).fill(s + 1);
 
   const arma::vec vB1 = clv::vec_hyp2F1(vRS, vHypArgB, vRSX1, vAbsAB/vMaxAB) / arma::pow(vMaxAB, r+s);
@@ -699,8 +699,8 @@ arma::vec pnbd_nocov_PMF(const double r,
                          const unsigned int x,
                          const arma::vec& vT_i){
 
-    const arma::vec vAlpha_i = clv::vec_fill(alpha_0, vT_i.n_elem);
-    const arma::vec vBeta_i = clv::vec_fill(beta_0, vT_i.n_elem);
+    const arma::vec vAlpha_i = arma::vec(vT_i.n_elem, arma::fill::value(alpha_0));
+    const arma::vec vBeta_i = arma::vec(vT_i.n_elem, arma::fill::value(beta_0));
 
     return(pnbd_PMF(r, s, x, vT_i, vAlpha_i, vBeta_i));
 }

--- a/src/pnbd.cpp
+++ b/src/pnbd.cpp
@@ -385,7 +385,7 @@ arma::vec pnbd_LL_ind(const double r,
                                   vHyp2f1ParamB(uvAlphaNeqBeta),
                                   r + s + vX(uvAlphaNeqBeta) + 1.0,
                                   vABabs(uvAlphaNeqBeta) / (vMaxAB(uvAlphaNeqBeta) + vT_cal(uvAlphaNeqBeta)))
-                                    % clv::vec_pow((vMaxAB(uvAlphaNeqBeta) + vT_x(uvAlphaNeqBeta))/(vMaxAB(uvAlphaNeqBeta) + vT_cal(uvAlphaNeqBeta)),
+                                    % arma::pow((vMaxAB(uvAlphaNeqBeta) + vT_x(uvAlphaNeqBeta))/(vMaxAB(uvAlphaNeqBeta) + vT_cal(uvAlphaNeqBeta)),
                                                    r + s + vX(uvAlphaNeqBeta)));
 
   vLog_Atilde(uvAlphaNeqBeta) = arma::log(vLog_Atilde(uvAlphaNeqBeta));
@@ -393,7 +393,7 @@ arma::vec pnbd_LL_ind(const double r,
 
   // .. log(Atilde) for alpha == beta --------------------------------------------------------
   // log(Atilde) = log(1 - (./.)^(r+s+x))
-  vLog_Atilde(uvAlphaEqBeta) = arma::log(1.0 - clv::vec_pow((vMaxAB(uvAlphaEqBeta) + vT_x(uvAlphaEqBeta)) / (vMaxAB(uvAlphaEqBeta) + vT_cal(uvAlphaEqBeta)),
+  vLog_Atilde(uvAlphaEqBeta) = arma::log(1.0 - arma::pow((vMaxAB(uvAlphaEqBeta) + vT_x(uvAlphaEqBeta)) / (vMaxAB(uvAlphaEqBeta) + vT_cal(uvAlphaEqBeta)),
                                          r + s + vX(uvAlphaEqBeta)));
 
 


### PR DESCRIPTION
Use native methods offered by armadillo which were not available at time of original implementation.

* `vec_pow()`: Replace with native `arma::pow()`. Available since version 0.11.4.0.1 (2022-10-01).
* `vec_fill()`: replace with native `arma::vec(arma::fill::value())`. Requires RcppArmadillo version 0.10.6.0.0 (2021-07-16) which is lower than already required.
* DESCRIPTION: Update required version for RcppArmadillo to 0.11.4.0.1 (2022-10-01)