### PR TITLE
`clv.time`: Accept `data.table::IDate` as inputs

### DIFF
--- a/R/class_clv_time_date.R
+++ b/R/class_clv_time_date.R
@@ -58,6 +58,17 @@ setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.
   return(user.timepoint)
 })
 
+
+setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.time="clv.time.date",
+                                                                            user.timepoint="IDate"), definition = function(clv.time, user.timepoint){
+  # data read with data.table::fread by default stores dates as data.table::IDate.
+  # data.table::IDate inherits from base::Date but still convert to base::Date
+  # to consistently return base::Date
+  return(as.Date(user.timepoint))
+})
+
+
+
 #' @importFrom lubridate floor_date
 setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.time="clv.time.date",
                                                                             user.timepoint="POSIXlt"), definition = function(clv.time, user.timepoint){
@@ -94,7 +105,7 @@ setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.
 setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.time="clv.time.date",
                                                                             user.timepoint="ANY"), definition = function(clv.time, user.timepoint){
   # None of these cases
-  stop("The provided data is in an unknown format! Only Date, POSIXct/lt, and character are accepted!", call. = FALSE)
+  stop("The provided data is in an unknown format! Only Date, data.table::IDate, POSIXct/lt, and character are accepted!", call. = FALSE)
 })
 
 

--- a/R/class_clv_time_datetime.R
+++ b/R/class_clv_time_datetime.R
@@ -85,6 +85,16 @@ definition = function(clv.time, user.timepoint){
   return(as.POSIXct.POSIXlt(tp.lt.midnight, tz = clv.time@timezone))
 })
 
+setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.time="clv.time.datetime",
+                                                                            user.timepoint="IDate"),
+definition = function(clv.time, user.timepoint){
+
+  # Data read with data.table::fread by default stores dates as data.table::IDate.
+  # Do not attempt own conversion but convert to super class base::Date and
+  # re-use existing method.
+  return(clv.time.convert.user.input.to.timepoint(clv.time=clv.time, user.timepoint=as.Date(user.timepoint)))
+})
+
 
 setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.time="clv.time.datetime",
                                                                             user.timepoint="POSIXlt"),
@@ -128,5 +138,5 @@ setMethod("clv.time.convert.user.input.to.timepoint", signature = signature(clv.
                                                                             user.timepoint="ANY"),
 definition = function(clv.time, user.timepoint){
   # None of these cases
-  stop("The provided data is in an unknown format! Only Date, POSIXct/lt, and character are accepted!", call. = FALSE)
+  stop("The provided data is in an unknown format! Only Date, data.table::IDate, POSIXct/lt, and character are accepted!", call. = FALSE)
 })

--- a/tests/testthat/helper_testthat_correctness_clvtime.R
+++ b/tests/testthat/helper_testthat_correctness_clvtime.R
@@ -391,11 +391,29 @@ fct.testthat.correctness.clvtime.convert.user.input.date.to.posixct <- function(
   })
 }
 
+fct.testthat.correctness.clvtime.convert.user.input.IDate.to.posixct <- function(clv.t.datetime){
+  stopifnot(is(clv.t.datetime, "clv.time.datetime"))
+  test_that("IDates convert to correct POSIX", {
+    expect_equal(lubridate::ymd_hms("2019-01-01 00:00:00", tz="UTC"),
+                 clv.time.convert.user.input.to.timepoint(clv.t.datetime, user.timepoint = data.table::as.IDate("2019-01-01")))
+    expect_equal(lubridate::ymd_hms("2019-12-18 00:00:00", tz="UTC"),
+                 clv.time.convert.user.input.to.timepoint(clv.t.datetime, user.timepoint = data.table::as.IDate("2019-12-18")))
+  })
+}
+
 fct.testthat.correctness.clvtime.convert.user.input.date.to.date <- function(clv.t.date){
   stopifnot(is(clv.t.date, "clv.time.date"))
   test_that("Dates convert to correct Dates", {
     expect_equal(lubridate::ymd("2019-01-01"), clv.time.convert.user.input.to.timepoint(clv.t.date, user.timepoint = lubridate::ymd("2019-01-01")))
     expect_equal(lubridate::ymd("2019-12-18"), clv.time.convert.user.input.to.timepoint(clv.t.date, user.timepoint = lubridate::ymd("2019-12-18")))
+  })
+}
+
+fct.testthat.correctness.clvtime.convert.user.input.IDate.to.date <- function(clv.t.date){
+  stopifnot(is(clv.t.date, "clv.time.date"))
+  test_that("IDates convert to correct Dates", {
+    expect_equal(lubridate::ymd("2019-01-01"), clv.time.convert.user.input.to.timepoint(clv.t.date, user.timepoint = data.table::as.IDate("2019-01-01")))
+    expect_equal(lubridate::ymd("2019-12-18"), clv.time.convert.user.input.to.timepoint(clv.t.date, user.timepoint = data.table::as.IDate("2019-12-18")))
   })
 }
 

--- a/tests/testthat/test_correctness_clvtime.R
+++ b/tests/testthat/test_correctness_clvtime.R
@@ -40,9 +40,11 @@ for(clv.t in c(fct.helper.clv.time.create.test.objects(with.holdout = FALSE),
     fct.testthat.correctness.clvtime.convert.user.input.chars.to.date(clv.t)
     fct.testthat.correctness.clvtime.convert.user.input.posixct.to.date(clv.t)
     fct.testthat.correctness.clvtime.convert.user.input.date.to.date(clv.t)
+    fct.testthat.correctness.clvtime.convert.user.input.IDate.to.date(clv.t)
   }else{
     fct.testthat.correctness.clvtime.convert.user.input.chars.to.posixct(clv.t)
     fct.testthat.correctness.clvtime.convert.user.input.date.to.posixct(clv.t)
+    fct.testthat.correctness.clvtime.convert.user.input.IDate.to.posixct(clv.t)
     fct.testthat.correctness.clvtime.convert.user.input.posixct.to.posixct(clv.t)
   }
 }


### PR DESCRIPTION
* data read with `data.table::fread` by default stores dates as `data.table::IDate`.
* `clv.time.convert.user.input.to.timepoint`: Add dispatch for `IDate` class.

Closes #255 .