### PR TITLE
Boots: Fix model selection by storing generics to fit model in `clv.model`

### DIFF
--- a/R/class_clv_model.R
+++ b/R/class_clv_model.R
@@ -25,6 +25,7 @@ setClass(Class = "clv.model", contains = "VIRTUAL",
            # Anything that will be used from main execution code.
            #  Enforce it through slots instead of relying on setting it in model generics
            name.model                  = "character",
+           fn.model.generic            = "standardGeneric",
 
            names.original.params.model = "character",
            names.prefixed.params.model = "character",

--- a/R/class_clv_model.R
+++ b/R/class_clv_model.R
@@ -9,6 +9,7 @@
 #' to obtain a functional \code{clv.fitted} object.
 #'
 #' @slot name.model Name of the model as it should be displayed
+#' @slot fn.model.generic Method (generic) to apply on (sub-class of) clv.data in order to fit the model.
 #' @slot names.original.params.model character vector that defines the names of the model parameters as they should be reported
 #' @slot names.prefixed.params.model character vector that defines the names of the model parameters as they are named during LL optimization
 #' @slot start.params.model numeric vector of default values at original scale that should be used for the LL optimization if the user does not provide start parameters. Named with \code{names.original.params.model}.

--- a/R/class_clv_model_bgnbd.R
+++ b/R/class_clv_model_bgnbd.R
@@ -13,6 +13,7 @@ setClass(Class = "clv.model.bgnbd.no.cov", contains = "clv.model.no.correlation"
 clv.model.bgnbd.no.cov <- function(){
   return(new("clv.model.bgnbd.no.cov",
              name.model = "BG/NBD Standard",
+             fn.model.generic = bgnbd,
              names.original.params.model = c(r="r", alpha="alpha", a="a", b="b"),
              names.prefixed.params.model = c("log.r", "log.alpha", "log.a", "log.b"),
              start.params.model = c(r=1, alpha = 3, a = 1, b = 3)))

--- a/R/class_clv_model_gg.R
+++ b/R/class_clv_model_gg.R
@@ -13,6 +13,7 @@ clv.model.gg <- function(){
 
   return(new("clv.model.gg",
              name.model                  = "Gamma-Gamma",
+             fn.model.generic            = gg,
              names.original.params.model = c(p="p", q="q", gamma="gamma"),
              names.prefixed.params.model = c(log.p="log.p", log.q="log.q", log.gamma="log.gamma"),
              start.params.model          = c(p=1, q=1, gamma=1),

--- a/R/class_clv_model_ggomnbd_nocov.R
+++ b/R/class_clv_model_ggomnbd_nocov.R
@@ -12,6 +12,7 @@ setClass(Class = "clv.model.ggomnbd.no.cov", contains = "clv.model.no.correlatio
 clv.model.ggomnbd.no.cov <- function(){
   return(new("clv.model.ggomnbd.no.cov",
              name.model = "GGompertz/NBD Standard",
+             fn.model.generic = ggomnbd,
              names.original.params.model = c(r="r", alpha="alpha", b="b", s="s", beta="beta"),
              names.prefixed.params.model = c("log.r","log.alpha", "log.b", "log.s", "log.beta"),
              start.params.model          = c(r=0.5, alpha=2, b=0.1, s=1, beta=0.1),

--- a/R/class_clv_model_pnbd.R
+++ b/R/class_clv_model_pnbd.R
@@ -14,6 +14,8 @@ clv.model.pnbd.no.cov <- function(){
 
   return(new("clv.model.pnbd.no.cov",
              name.model                  = "Pareto/NBD Standard",
+             fn.model.generic            = pnbd,
+
              names.original.params.model = c(r="r", alpha="alpha", s="s", beta="beta"),
              names.prefixed.params.model = c("log.r","log.alpha", "log.s", "log.beta"),
              start.params.model          = c(r=0.5, alpha=15, s=0.5, beta=10),

--- a/R/f_generics_clvfitted.R
+++ b/R/f_generics_clvfitted.R
@@ -28,13 +28,7 @@ setMethod("clv.fitted.estimate.same.specification.on.new.data", signature = "clv
   # overwrite with what was passed
   args <- modifyList(args, val = list(...), keep.null = TRUE)
 
-  new.fitted <- do.call(
-    what = switch (class(clv.fitted@clv.model),
-                   "clv.model.pnbd.no.cov"= pnbd,
-                   "clv.model.bgnbd.no.cov" = bgnbd,
-                   "clv.model.ggomnbd.no.cov" = ggomnbd,
-                   "clv.model.gg" = gg),
-    args=args)
+  new.fitted <- do.call(what = clv.fitted@clv.model@fn.model.generic, args=args)
 
   new.fitted@call <- cl
   return(new.fitted)

--- a/man/clv.model-class.Rd
+++ b/man/clv.model-class.Rd
@@ -17,6 +17,8 @@ to obtain a functional \code{clv.fitted} object.
 \describe{
 \item{\code{name.model}}{Name of the model as it should be displayed}
 
+\item{\code{fn.model.generic}}{Method (generic) to apply on (sub-class of) clv.data in order to fit the model.}
+
 \item{\code{names.original.params.model}}{character vector that defines the names of the model parameters as they should be reported}
 
 \item{\code{names.prefixed.params.model}}{character vector that defines the names of the model parameters as they are named during LL optimization}


### PR DESCRIPTION
Store generics to fit model in `clv.model`. Required during bootstrapping to select method to apply based on clv.model.