### PR TITLE
`clv.bootstrapped.apply`: Rename `num.boot` -> `num.boots`

### DIFF
--- a/R/f_generics_clvfittedspending.R
+++ b/R/f_generics_clvfittedspending.R
@@ -128,7 +128,7 @@ setMethod(f = "clv.fitted.bootstrap.predictions",signature = signature(clv.fitte
 
   l.boots <- clv.bootstrapped.apply(
     object = clv.fitted,
-    num.boot = num.boots,
+    num.boots = num.boots,
     fn.boot.apply = boots.predict,
     fn.sample = NULL,
     verbose = FALSE,

--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -377,7 +377,7 @@ setMethod(f = "clv.fitted.bootstrap.predictions", signature = signature(clv.fitt
 
   l.boots <- clv.bootstrapped.apply(
     object = clv.fitted,
-    num.boot = num.boots,
+    num.boots = num.boots,
     fn.boot.apply = boots.predict,
     fn.sample = NULL,
     verbose = FALSE,

--- a/R/f_interface_bootstrappedapply.R
+++ b/R/f_interface_bootstrappedapply.R
@@ -21,7 +21,7 @@
 #'
 #'
 #' @param object Fitted model
-#' @param num.boot number of times to sample data and re-fit the model
+#' @param num.boots number of times to sample data and re-fit the model
 #' @param fn.sample Method sampling customer ids for creating the bootstrapped data. Receives and returns
 #'  a vector of ids (string). If \code{NULL}, ids are sampled with replacement until reaching original length. See examples.
 #' @param fn.boot.apply Method to apply on each model estimated on the sampled data. See examples.
@@ -46,7 +46,7 @@
 #'
 #' # bootstrapped model coefs while sampling 50 percent
 #' # of customers without replacement
-#' clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.boot.apply=coef,
+#' clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.boot.apply=coef,
 #' fn.sample=function(x){
 #' sample(x, size = as.integer(0.5*length(x)), replace = FALSE)})
 #'
@@ -57,12 +57,12 @@
 #' # data contains the same estimation and holdout periods
 #' # as the original data, even if the transactions of the sampled
 #' # customers .
-#' clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.sample=NULL,
+#' clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.sample=NULL,
 #' fn.boot.apply=function(x){predict(x)})
 #'
 #' # return the fitted models
 #' # forward additional arguments to the model fitting method
-#' clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.sample=NULL,
+#' clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.sample=NULL,
 #' fn.boot.apply=return,
 #' # args for ..., forwarded to pnbd()
 #' verbose=FALSE, optimx.args=list(method="Nelder-Mead"),
@@ -70,7 +70,7 @@
 #' }
 #'
 #' @export
-clv.bootstrapped.apply <- function(object, num.boot, fn.boot.apply, fn.sample=NULL, ...){
+clv.bootstrapped.apply <- function(object, num.boots, fn.boot.apply, fn.sample=NULL, ...){
   # cran silence
   Id <- NULL
 

--- a/R/f_interface_bootstrappedapply.R
+++ b/R/f_interface_bootstrappedapply.R
@@ -74,7 +74,7 @@ clv.bootstrapped.apply <- function(object, num.boots, fn.boot.apply, fn.sample=N
   # cran silence
   Id <- NULL
 
-  check_err_msg(check_user_data_numboots(num.boots=num.boot))
+  check_err_msg(check_user_data_numboots(num.boots=num.boots))
   check_err_msg(check_user_data_fnbootapply(fn.boot.apply=fn.boot.apply))
   check_err_msg(check_user_data_fnsample(fn.sample=fn.sample))
 
@@ -86,7 +86,7 @@ clv.bootstrapped.apply <- function(object, num.boots, fn.boot.apply, fn.sample=N
 
   ids <- object@cbs[, unique(Id)]
 
-  l.boots <- lapply(seq_len(num.boot), function(i){
+  l.boots <- lapply(seq_len(num.boots), function(i){
 
     clv.data.boot <- clv.data.create.bootstrapping.data(
       clv.data = object@clv.data,

--- a/man/clv.bootstrapped.apply.Rd
+++ b/man/clv.bootstrapped.apply.Rd
@@ -4,12 +4,12 @@
 \alias{clv.bootstrapped.apply}
 \title{Bootstrapping: Fit a model again on sampled data and apply method}
 \usage{
-clv.bootstrapped.apply(object, num.boot, fn.boot.apply, fn.sample = NULL, ...)
+clv.bootstrapped.apply(object, num.boots, fn.boot.apply, fn.sample = NULL, ...)
 }
 \arguments{
 \item{object}{Fitted model}
 
-\item{num.boot}{number of times to sample data and re-fit the model}
+\item{num.boots}{number of times to sample data and re-fit the model}
 
 \item{fn.boot.apply}{Method to apply on each model estimated on the sampled data. See examples.}
 
@@ -50,7 +50,7 @@ pnbd.cdnow <- pnbd(clv.cdnow)
 
 # bootstrapped model coefs while sampling 50 percent
 # of customers without replacement
-clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.boot.apply=coef,
+clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.boot.apply=coef,
 fn.sample=function(x){
 sample(x, size = as.integer(0.5*length(x)), replace = FALSE)})
 
@@ -61,12 +61,12 @@ sample(x, size = as.integer(0.5*length(x)), replace = FALSE)})
 # data contains the same estimation and holdout periods
 # as the original data, even if the transactions of the sampled
 # customers .
-clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.sample=NULL,
+clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.sample=NULL,
 fn.boot.apply=function(x){predict(x)})
 
 # return the fitted models
 # forward additional arguments to the model fitting method
-clv.bootstrapped.apply(pnbd.cdnow, num.boot=5, fn.sample=NULL,
+clv.bootstrapped.apply(pnbd.cdnow, num.boots=5, fn.sample=NULL,
 fn.boot.apply=return,
 # args for ..., forwarded to pnbd()
 verbose=FALSE, optimx.args=list(method="Nelder-Mead"),

--- a/tests/testthat/test_correctness_bootstrapping.R
+++ b/tests/testthat/test_correctness_bootstrapping.R
@@ -390,7 +390,7 @@ test_that("Sampling all customers leads to same model estimate (nocov, static co
   for(clv.fitted in list(bg.cdnow, bg.apparel.static, p.apparel.dyn, gg.cdnow)){
 
     fn.sample.all <- function(){
-      return(clv.bootstrapped.apply(clv.fitted, num.boot = 1, fn.boot.apply = coef, fn.sample = function(ids){return(ids)})[[1]])
+      return(clv.bootstrapped.apply(clv.fitted, num.boots = 1, fn.boot.apply = coef, fn.sample = function(ids){return(ids)})[[1]])
     }
 
     if(is(clv.fitted, "clv.pnbd.dynamic.cov")){
@@ -408,7 +408,7 @@ test_that("Sampling all customers leads to same model estimate (nocov, static co
 test_that("Predict to same prediction end if given num periods even if sampled transactions would not define same estimation end", {
   dt.pred.boot <- clv.bootstrapped.apply(
     bg.cdnow,
-    num.boot = 1,
+    num.boots = 1,
     fn.boot.apply = function(clv.fitted){
       return(predict(clv.fitted, prediction.end=99, predict.spending=FALSE, verbose=FALSE))
       },

--- a/tests/testthat/test_inputchecks_bootstrapping.R
+++ b/tests/testthat/test_inputchecks_bootstrapping.R
@@ -8,7 +8,7 @@ test_that("clv.bootstrapped.apply(num.boot) may only be an integer > 0", {
   fn.expect.num.boot.greater0 <- function(n){
     expect_error(clv.bootstrapped.apply(
       object = bg.cdnow,
-      num.boot = n,
+      num.boots = n,
       fn.boot.apply = function(x){x},
       fn.sample = NULL
     ), 'num.boots')
@@ -26,7 +26,7 @@ test_that("clv.bootstrapped.apply(fn.boot.apply) may only be a function", {
   fn.expect.fn.apply <- function(fn.apply){
     expect_error(clv.bootstrapped.apply(
       object = bg.cdnow,
-      num.boot = 1000,
+      num.boots = 1000,
       fn.boot.apply = fn.apply,
       fn.sample = NULL
     ), 'fn.boot.apply')
@@ -44,7 +44,7 @@ test_that("clv.bootstrapped.apply(fn.sample) may only be a function", {
   fn.expect.fn.sample <- function(fn.sample){
     expect_error(clv.bootstrapped.apply(
       object = bg.cdnow,
-      num.boot = 1000,
+      num.boots = 1000,
       fn.boot.apply = function(x){x},
       fn.sample = fn.sample
     ), 'fn.sample')

--- a/tests/testthat/test_runability_bootstrapping.R
+++ b/tests/testthat/test_runability_bootstrapping.R
@@ -12,7 +12,7 @@ set.seed(124)
 
 fct.testthat.clv.boostrapped.apply.downstream.methods.work.on.boots <- function(clv.fitted, newdata.nohold, newdata.withhold){
   test_that("Downstream methods work on all transaction models fitted on bootstrapped data", {
-    clv.bootstrapped.apply(clv.fitted, num.boot=1, fn.boot.apply=function(boots.fitted){
+    clv.bootstrapped.apply(clv.fitted, num.boots=1, fn.boot.apply=function(boots.fitted){
 
       fct.helper.clvfittedtransactions.all.s3(
         clv.fitted=boots.fitted,
@@ -35,7 +35,7 @@ fct.testthat.clv.bootstrapped.apply.ellipsis.works <- function(clv.fitted){
 
     expect_warning(l.boots <- clv.bootstrapped.apply(
       clv.fitted,
-      num.boot=1,
+      num.boots=1,
       fn.boot.apply=function(o){return(o)},
       optimx.args=list(method='CG', itnmax=5, hessian=FALSE, control=list(kkt=FALSE))
     ), regexp = 'Hessian')
@@ -159,7 +159,7 @@ for(clv.fitted in list(
   # . clv.bootstrapped.apply ----------------------------------------------------
 
   # Expect warning because again fitted without hessian
-  expect_warning(clv.bootstrapped.apply(clv.fitted, num.boot=1, fn.boot.apply=function(boots.fitted){
+  expect_warning(clv.bootstrapped.apply(clv.fitted, num.boots=1, fn.boot.apply=function(boots.fitted){
 
 
     # Basic S3
@@ -233,7 +233,7 @@ for(clv.fitted in list(
 )){
 
   # . clv.bootstrapped.apply ---------------------------------------------------
-  clv.bootstrapped.apply(clv.fitted, num.boot=1, fn.boot.apply=function(boots.fitted){
+  clv.bootstrapped.apply(clv.fitted, num.boots=1, fn.boot.apply=function(boots.fitted){
 
     # Basic S3
     expect_silent(coef(boots.fitted))


### PR DESCRIPTION
For consistency with `predict(num.boots)`