### PR TITLE
Add `SystemRequirements` to `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ URL: https://github.com/bachmannpatrick/CLVTools
 BugReports: https://github.com/bachmannpatrick/CLVTools/issues
 NeedsCompilation: yes
 LinkingTo: Rcpp, RcppArmadillo (>= 0.11.4.0.1), RcppGSL (>= 0.3.7), testthat
+SystemRequirements: GNU GSL
 LazyLoad: yes
 Encoding: UTF-8
 Collate: 


### PR DESCRIPTION
Explicitly name GSL as a external, non-R system dependency