### PR TITLE
Replace RcppGSL::Vector with arma::vec

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -254,28 +254,28 @@ BEGIN_RCPP
 END_RCPP
 }
 // vec_gsl_hyp2f0_e
-Rcpp::List vec_gsl_hyp2f0_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vZ);
+Rcpp::List vec_gsl_hyp2f0_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vZ);
 RcppExport SEXP _CLVTools_vec_gsl_hyp2f0_e(SEXP vASEXP, SEXP vBSEXP, SEXP vZSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vA(vASEXP);
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vB(vBSEXP);
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vZ(vZSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vA(vASEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vB(vBSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vZ(vZSEXP);
     rcpp_result_gen = Rcpp::wrap(vec_gsl_hyp2f0_e(vA, vB, vZ));
     return rcpp_result_gen;
 END_RCPP
 }
 // vec_gsl_hyp2f1_e
-Rcpp::List vec_gsl_hyp2f1_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vC, const RcppGSL::Vector& vZ);
+Rcpp::List vec_gsl_hyp2f1_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vC, const arma::vec& vZ);
 RcppExport SEXP _CLVTools_vec_gsl_hyp2f1_e(SEXP vASEXP, SEXP vBSEXP, SEXP vCSEXP, SEXP vZSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vA(vASEXP);
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vB(vBSEXP);
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vC(vCSEXP);
-    Rcpp::traits::input_parameter< const RcppGSL::Vector& >::type vZ(vZSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vA(vASEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vB(vBSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vC(vCSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type vZ(vZSEXP);
     rcpp_result_gen = Rcpp::wrap(vec_gsl_hyp2f1_e(vA, vB, vC, vZ));
     return rcpp_result_gen;
 END_RCPP

--- a/src/clv_vectorized.cpp
+++ b/src/clv_vectorized.cpp
@@ -11,23 +11,23 @@
 //' @return List with vector of values and vector of gsl status codes
 //' @keywords internal
 // [[Rcpp::export]]
-Rcpp::List vec_gsl_hyp2f0_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vZ){
+Rcpp::List vec_gsl_hyp2f0_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vZ){
 
-  if((vA->size != vB->size) || (vB->size != vZ->size))
+  if((vA.n_elem != vB.n_elem) || (vB.n_elem != vZ.n_elem))
     throw std::runtime_error(std::string("Not all vectors are of the same length!"));
 
   // Do not abort in case of error
   gsl_set_error_handler_off();
 
-  const size_t n = vA->size;
+  const arma::uword n = vA.n_elem;
 
-  RcppGSL::Vector vRes(n);
-  RcppGSL::IntVector vStatus(n);
+  arma::vec vRes(n);
+  arma::ivec vStatus(n);
   gsl_sf_result gsl_res;
 
-  for(size_t i = 0; i<n; i++){
-    vStatus[i] = gsl_sf_hyperg_2F0_e(vA[i], vB[i], vZ[i], &gsl_res);
-    vRes[i] = gsl_res.val;
+  for(arma::uword i = 0; i<n; i++){
+    vStatus(i) = gsl_sf_hyperg_2F0_e(vA(i), vB(i), vZ(i), &gsl_res);
+    vRes(i) = gsl_res.val;
     // gsl_res.err
   }
 
@@ -46,23 +46,23 @@ Rcpp::List vec_gsl_hyp2f0_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB
 //' @return List with vector of values and vector of gsl status codes
 //' @keywords internal
 // [[Rcpp::export]]
-Rcpp::List vec_gsl_hyp2f1_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vC, const RcppGSL::Vector& vZ){
+Rcpp::List vec_gsl_hyp2f1_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vC, const arma::vec& vZ){
 
-  if((vA->size != vB->size) || (vB->size != vC->size) || (vC->size != vZ->size))
+  if((vA.n_elem != vB.n_elem) || (vB.n_elem != vC.n_elem) || (vC.n_elem != vZ.n_elem))
     throw std::runtime_error(std::string("Not all vectors are of the same length!"));
 
   // Do not abort in case of error
   gsl_set_error_handler_off();
 
-  const size_t n = vA->size;
+  const arma::uword n = vA.n_elem;
 
-  RcppGSL::Vector vRes(n);
-  RcppGSL::IntVector vStatus(n);
+  arma::vec vRes(n);
+  arma::ivec vStatus(n);
   gsl_sf_result gsl_res;
 
-  for(size_t i = 0; i<n; i++){
-    vStatus[i] = gsl_sf_hyperg_2F1_e(vA[i], vB[i], vC[i], vZ[i], &gsl_res);
-    vRes[i] = gsl_res.val;
+  for(arma::uword i = 0; i<n; i++){
+    vStatus(i) = gsl_sf_hyperg_2F1_e(vA(i), vB(i), vC(i), vZ(i), &gsl_res);
+    vRes(i) = gsl_res.val;
   }
 
   return Rcpp::List::create(Rcpp::Named("value") = Rcpp::wrap(vRes),

--- a/src/clv_vectorized.h
+++ b/src/clv_vectorized.h
@@ -7,9 +7,9 @@
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_sf_result.h>
 
-Rcpp::List vec_gsl_hyp2f0_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vZ);
+Rcpp::List vec_gsl_hyp2f0_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vZ);
 
-Rcpp::List vec_gsl_hyp2f1_e(const RcppGSL::Vector& vA, const RcppGSL::Vector& vB, const RcppGSL::Vector& vC, const RcppGSL::Vector& vZ);
+Rcpp::List vec_gsl_hyp2f1_e(const arma::vec& vA, const arma::vec& vB, const arma::vec& vC, const arma::vec& vZ);
 
 namespace clv{
 


### PR DESCRIPTION
There is no requirement to use RcppGSL vectors to call GSL methods as they are called with scalars.