### PR TITLE
Predict (uncertainty): Refit with exact original specification

### DIFF
--- a/R/f_generics_clvfitted.R
+++ b/R/f_generics_clvfitted.R
@@ -23,9 +23,11 @@ setMethod(f = "clv.controlflow.predict.set.prediction.params", signature = signa
 setMethod("clv.fitted.estimate.same.specification.on.new.data", signature = "clv.fitted", def = function(clv.fitted, newdata, ...){
   cl <- match.call(expand.dots = TRUE)
 
+  # args to model function are the original specification args + `newdata` as
+  # actual data arg
   args <- c(clv.fitted@model.specification.args, list(clv.data=newdata))
 
-  # overwrite with what was passed
+  # overwrite call args with what was passed
   args <- modifyList(args, val = list(...), keep.null = TRUE)
 
   new.fitted <- do.call(what = clv.fitted@clv.model@fn.model.generic, args=args)

--- a/R/f_generics_clvfittedspending.R
+++ b/R/f_generics_clvfittedspending.R
@@ -103,6 +103,7 @@ setMethod("clv.controlflow.predict.post.process.prediction.table", signature = s
 setMethod(f = "clv.fitted.bootstrap.predictions",signature = signature(clv.fitted="clv.fitted.spending"), definition = function(clv.fitted, num.boots, verbose){
 
   # Largely the same as for clv.fitted.transactions but with different arguments to predict()
+  # See there for more in-depth comments
 
 
   if(verbose){
@@ -117,9 +118,11 @@ setMethod(f = "clv.fitted.bootstrap.predictions",signature = signature(clv.fitte
   }
   pb.i <- 0
 
+
   boots.predict <- function(clv.boot){
     pb.i <<- pb.i + 1
     update.pb(n = pb.i)
+
     return(predict(
       object = clv.boot,
       verbose = FALSE,
@@ -130,9 +133,9 @@ setMethod(f = "clv.fitted.bootstrap.predictions",signature = signature(clv.fitte
     object = clv.fitted,
     num.boots = num.boots,
     fn.boot.apply = boots.predict,
-    fn.sample = NULL,
     verbose = FALSE,
-    start.params.model = clv.fitted@prediction.params.model
+    fn.sample = NULL
   )
+
   return(rbindlist(l.boots))
 })

--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -371,11 +371,12 @@ setMethod(f = "clv.fitted.bootstrap.predictions", signature = signature(clv.fitt
 
   l.boots <- clv.bootstrapped.apply(
     object = clv.fitted,
+    fn.sample = NULL,
     num.boots = num.boots,
     fn.boot.apply = boots.predict,
-    fn.sample = NULL,
-    verbose = FALSE,
-    start.params.model = clv.fitted@prediction.params.model
+    # Fitting on bootstrapped data: Never verbose because does not mix well
+    # with status bar shown when verbose=TRUE
+    verbose = FALSE
   )
 
   return(rbindlist(l.boots))

--- a/R/f_generics_clvfittedtransactions.R
+++ b/R/f_generics_clvfittedtransactions.R
@@ -344,13 +344,6 @@ setMethod("clv.controlflow.predict.new.customer", signature = signature(clv.fitt
 # . clv.fitted.bootstrap.predictions --------------------------------------------
 setMethod(f = "clv.fitted.bootstrap.predictions", signature = signature(clv.fitted="clv.fitted.transactions"), definition = function(clv.fitted, num.boots, verbose, prediction.end, predict.spending, continuous.discount.factor){
 
-  # have to explicitly give prediction.end because bootstrapping data has no holdout
-  if(is.null(prediction.end)){
-    boots.prediction.end <- clv.fitted@clv.data@clv.time@timepoint.holdout.end
-  }else{
-    boots.prediction.end <- prediction.end
-  }
-
   if(verbose){
     # Print message before progress bar is created
     message("Bootstrapping ",num.boots," times for uncertainty estimates...")
@@ -358,17 +351,18 @@ setMethod(f = "clv.fitted.bootstrap.predictions", signature = signature(clv.fitt
     progress.bar <- txtProgressBar(max = num.boots, style = 3)
     update.pb    <- function(n){setTxtProgressBar(pb=progress.bar, value = n)}
   }else{
-    # has to be also defined if verbose=F because used in boots.predict
+    # also has to be defined if verbose=F because used in boots.predict
     update.pb <- function(n){}
   }
   pb.i <- 0
 
+  # Method that is called on the bootstrapped data
   boots.predict <- function(clv.boot){
     pb.i <<- pb.i + 1
     update.pb(n = pb.i)
     return(predict(
       object = clv.boot,
-      prediction.end = boots.prediction.end,
+      prediction.end = prediction.end,
       verbose = FALSE,
       predict.spending = predict.spending,
       continuous.discount.factor = continuous.discount.factor,


### PR DESCRIPTION
- Not required to derive `prediction.end` anymore as bootstrapped data by now keeps holdout period
- Do not use estimated parameters as start params for bootstrapped model fitting anymore