### PR TITLE
Improved optimx default args

### DIFF
--- a/R/class_clv_model_bgnbd.R
+++ b/R/class_clv_model_bgnbd.R
@@ -16,7 +16,17 @@ clv.model.bgnbd.no.cov <- function(){
              fn.model.generic = bgnbd,
              names.original.params.model = c(r="r", alpha="alpha", a="a", b="b"),
              names.prefixed.params.model = c("log.r", "log.alpha", "log.a", "log.b"),
-             start.params.model = c(r=1, alpha = 3, a = 1, b = 3)))
+             start.params.model = c(r=1, alpha = 3, a = 1, b = 3),
+             optimx.defaults = list(
+               method = "L-BFGS-B",
+               itnmax  = 5000,
+               control = list(
+                 kkt = TRUE,
+                 save.failures = TRUE,
+                 # Do not perform start tests because it checks the scales with max(logpar)-min(logpar)
+                 #   but all standard start parameters are <= 0, hence there are no logpars what
+                 #   produces a warning
+                 starttests = FALSE))))
 }
 
 # Methods --------------------------------------------------------------------------------------------------------------------------------

--- a/R/class_clv_model_gg.R
+++ b/R/class_clv_model_gg.R
@@ -17,17 +17,16 @@ clv.model.gg <- function(){
              names.original.params.model = c(p="p", q="q", gamma="gamma"),
              names.prefixed.params.model = c(log.p="log.p", log.q="log.q", log.gamma="log.gamma"),
              start.params.model          = c(p=1, q=1, gamma=1),
-             optimx.defaults = list(method = "L-BFGS-B",
-                                    itnmax  = 3000,
-                                    # upper  = c(log(10000),log(10000),log(10000)),
-                                    # lower  = c(log(0),log(0),log(0)),
-                                    control = list(
-                                      kkt = TRUE,
-                                      save.failures = TRUE,
-                                      # Do not perform starttests because it checks the scales with max(logpar)-min(logpar)
-                                      #   but all standard start parameters are <= 0, hence there are no logpars what
-                                      #   produces a warning
-                                      starttests = FALSE))))
+             optimx.defaults = list(
+               method = "L-BFGS-B",
+               itnmax  = 5000,
+               control = list(
+                 kkt = TRUE,
+                 save.failures = TRUE,
+                 # Do not perform start tests because it checks the scales with max(logpar)-min(logpar)
+                 #   but all standard start parameters are <= 0, hence there are no logpars what
+                 #   produces a warning
+                 starttests = FALSE))))
 }
 
 # Methods --------------------------------------------------------------------------------------------------------------------------------

--- a/R/class_clv_model_ggomnbd_nocov.R
+++ b/R/class_clv_model_ggomnbd_nocov.R
@@ -16,16 +16,16 @@ clv.model.ggomnbd.no.cov <- function(){
              names.original.params.model = c(r="r", alpha="alpha", b="b", s="s", beta="beta"),
              names.prefixed.params.model = c("log.r","log.alpha", "log.b", "log.s", "log.beta"),
              start.params.model          = c(r=0.5, alpha=2, b=0.1, s=1, beta=0.1),
-             optimx.defaults = list(method = "L-BFGS-B",
-                                    itnmax  = 5000,
-                                    control = list(
-                                      kkt = TRUE,
-                                      all.methods = FALSE,
-                                      save.failures = TRUE,
-                                      # Do not perform starttests because it checks the scales with max(logpar)-min(logpar)
-                                      #   but all standard start parameters are <= 0, hence there are no logpars what
-                                      #   produces a warning
-                                      starttests = FALSE))))
+             optimx.defaults = list(
+               method = "L-BFGS-B",
+               itnmax  = 5000,
+               control = list(
+                 kkt = TRUE,
+                 save.failures = TRUE,
+                 # Do not perform start tests because it checks the scales with max(logpar)-min(logpar)
+                 #   but all standard start parameters are <= 0, hence there are no logpars what
+                 #   produces a warning
+                 starttests = FALSE))))
 }
 
 # Methods --------------------------------------------------------------------------------------------------------------------------------

--- a/R/class_clv_model_pnbd.R
+++ b/R/class_clv_model_pnbd.R
@@ -19,17 +19,16 @@ clv.model.pnbd.no.cov <- function(){
              names.original.params.model = c(r="r", alpha="alpha", s="s", beta="beta"),
              names.prefixed.params.model = c("log.r","log.alpha", "log.s", "log.beta"),
              start.params.model          = c(r=0.5, alpha=15, s=0.5, beta=10),
-             optimx.defaults = list(method = "L-BFGS-B",
-                                    # lower   = c(log(1*10^(-5)),log(1*10^(-5)),log(1*10^(-5)),log(1*10^(-5))),
-                                    # upper   = c(log(300),log(2000),log(300),log(2000)),
-                                    itnmax  = 3000,
-                                    control = list(
-                                      kkt = TRUE,
-                                      save.failures = TRUE,
-                                      # Do not perform starttests because it checks the scales with max(logpar)-min(logpar)
-                                      #   but all standard start parameters are <= 0, hence there are no logpars what
-                                      #   produces a warning
-                                      starttests = FALSE))))
+             optimx.defaults = list(
+               method = "L-BFGS-B",
+               itnmax  = 5000,
+               control = list(
+                 kkt = TRUE,
+                 save.failures = TRUE,
+                 # Do not perform start tests because it checks the scales with max(logpar)-min(logpar)
+                 #   but all standard start parameters are <= 0, hence there are no logpars what
+                 #   produces a warning
+                 starttests = FALSE))))
 }
 
 

--- a/R/class_clv_model_pnbd_dynamiccov.R
+++ b/R/class_clv_model_pnbd_dynamiccov.R
@@ -18,7 +18,7 @@ clv.model.pnbd.dynamic.cov <- function(){
              name.model       = "Pareto/NBD with Dynamic Covariates",
              # Overwrite optimx default args
              optimx.defaults  = list(method = "Nelder-Mead",
-                                     itnmax = 3000,
+                                     itnmax = 50000,
                                      control = list(
                                        kkt = TRUE,
                                        save.failures = TRUE,


### PR DESCRIPTION
* Harmonize optimx defaults for nocov/static cov models and GG: `method = "L-BFGS-B", itnmax=5000, kkt = TRUE, save.failures = TRUE, starttests = FALSE)`

* Significantly increase the default number of iterations for dyncov models (`itnmax`) from 3000 to 50000. The previous iteration limit is rather low for NelderMead and in practice was often reached. This likely mislead users to believe that the optimization converged when in reality it only stopped because the max num iterations had been reached.