### PR TITLE
PNBD Dyncov: Improved optimx defaults (higher `itnmax`)

### DIFF
--- a/R/class_clv_model_pnbd_dynamiccov.R
+++ b/R/class_clv_model_pnbd_dynamiccov.R
@@ -18,7 +18,7 @@ clv.model.pnbd.dynamic.cov <- function(){
              name.model       = "Pareto/NBD with Dynamic Covariates",
              # Overwrite optimx default args
              optimx.defaults  = list(method = "Nelder-Mead",
-                                     itnmax = 3000,
+                                     itnmax = 50000,
                                      control = list(
                                        kkt = TRUE,
                                        save.failures = TRUE,


### PR DESCRIPTION
Significantly increase the default number of iterations for dyncov models (`itnmax`) from 3000 to 50000. The previous iteration limit is rather low for NelderMead and in practice was often reached. This likely mislead users to believe that the optimization converged when in reality it only stopped because the max num iterations had been reached.