### PR TITLE
Set zval and pval of main model params to NA

### DIFF
--- a/R/f_s3generics_clvfitted.R
+++ b/R/f_s3generics_clvfitted.R
@@ -370,6 +370,14 @@ summary.clv.fitted <- function(object, ...){
   rownames(res$coefficients) <- names(all.est.params)
   colnames(res$coefficients) <- c("Estimate","Std. Error", "z-val", "Pr(>|z|)")
 
+  # Set z-val and Pvalue of the model parameters to NA as they are by definition always > 0 ("significant")
+  # Printing "-" would be preferred but
+  #   - setting to "-" would convert the whole matrix to character
+  #   - using `printCoefmat(na.print='-')` would also show "-" for NA parameter estimates
+  #   - therefore would likely require to re-implement `printCoefmat()` to only na.print
+  #     for some params & columns but this is cumbersome as na.print is from the internal `print.default`
+  res$coefficients[object@clv.model@names.original.params.model, c("z-val", "Pr(>|z|)")] <- NA_real_
+
   # Optimization -------------------------------------------------------------------
   res$estimated.LL <- as.vector(logLik(object))
   res$AIC <- AIC(object)

--- a/tests/testthat/helper_testthat_correctness_clvfitted.R
+++ b/tests/testthat/helper_testthat_correctness_clvfitted.R
@@ -3,8 +3,11 @@ fct.testthat.correctness.clvfitted.flawless.results.out.of.the.box <- function(m
     skip_on_cran()
     expect_silent(fitted <- do.call(what = method, args = list(clv.data, verbose = FALSE)))
     expect_silent(res.sum <- summary(fitted))
-    # No NAs anywhere
-    expect_false(any(!is.finite(coef(res.sum)))) # vcov and coef together
+
+    # No NAs in the parameter estimates and SE (checks vcov and coef together)
+    # There are however NAs in zval and pval as they are on purpose set to NA for the main model params
+    expect_false(any(!is.finite(coef(res.sum)[, c("Estimate", "Std. Error")])))
+
     fct.DT.any.non.finite <- function(DT){
       return(DT[, any(sapply(.SD, function(x){any(!is.finite(x))})), .SDcols = DT[, sapply(.SD, is.numeric)]])
     }


### PR DESCRIPTION
By definition, they are always >0 and assessing their significance is pointless